### PR TITLE
Handle Enum when making QVariant

### DIFF
--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -1031,7 +1031,7 @@ QVariant PythonQtConv::PyObjToQVariant(PyObject* val, int type)
       type = QVariant::Invalid;
     } else if (PyDict_Check(val)) {
       type = QVariant::Map;
-    } else if (PyList_Check(val) || PyTuple_Check(val) || PySequence_Check(val)) {
+    } else if (PyList_Check(val) || PyTuple_Check(val) || (PySequence_Check(val) && strcmp(val->ob_type->tp_name, "EnumMeta") != 0)) {
       type = QVariant::List;
     } else {
       // transport the Python objects directly inside of QVariant:


### PR DESCRIPTION
_Moved here from https://sourceforge.net/p/pythonqt/discussion/631392/thread/bf34b51907/_

# Background
When running some Python code from PythonQt the other day, I got a segfault in [PythonQtConversion.cpp](https://github.com/MeVisLab/pythonqt/blob/170d4a475ed6c438a6b844849cf320c40e9ab02b/src/PythonQtConversion.cpp#L982). It turned out that when an Enum based class is processed by `PyObjToQVariant`, it's recognised as a sequence (since it's possible to iterate over an Enum in Python), but `PySequence_GetItem` returns nullptr [when the loop gets the value to add to the QVariantList](https://github.com/MeVisLab/pythonqt/blob/170d4a475ed6c438a6b844849cf320c40e9ab02b/src/PythonQtConversion.cpp#L1165), causing the segfault when calling `PyObjToVariant` with a null pointer. Unless Enums should be treated in a special way, I assume that the best is to handle them as "normal" classes. In order to do that I created a small patch that checks if `val->ob_type->tp_name` is "EnumMeta". I'm not sure if this is an acceptable solution, so I'm open for better ways to fix it.

Python 2.7 (with enum34 installed) and 3.6 behave the same.

# Files

Supplied files:

[enumtest.zip](https://github.com/MeVisLab/pythonqt/files/3330843/enumtest.zip):

- pythonqt_run_enum_test.cpp: Minimal application that shows the problem
- enumtest.py: Python module with an Enum for use with the test program


# Minimal example
## Building
Building the test application (very manual – I ran this on Xubuntu 18.10):
```sh
g++ -fPIC -c `pkg-config --cflags Qt5Core python-3.6 PythonQt-Qt5-Python3` -o pythonqt_run_enum_test.o pythonqt_run_enum_test.cpp
g++ -o pythonqt_run_enum_test pythonqt_run_enum_test.o `pkg-config --libs Qt5Core python-3.6 PythonQt-Qt5-Python3`
./pythonqt_run_enum_test
```
## Expected output
Without the patch, there is a segfault when running the minimal example. With the patch applied, it outputs this:
```
QVariant(QVariantList, (QVariant(QVariantList, (QVariant(QString, "Color"), QVariant(PythonQtObjectPtr, ))), QVariant(QVariantList, (QVariant(QString, "Enum"), QVariant(PythonQtObjectPtr, )))))
```

# Links regarding Enum
- [Python doc: How are Enums different?](https://docs.python.org/3/library/enum.html#how-are-enums-different)
- [Source code of Enum](https://github.com/python/cpython/blob/master/Lib/enum.py)