### PR TITLE
Use `quote` characters around includes of PythonQt headers.

### DIFF
--- a/src/PythonQtObjectPtr.cpp
+++ b/src/PythonQtObjectPtr.cpp
@@ -39,8 +39,8 @@
 */
 //----------------------------------------------------------------------------------
 
-#include <PythonQt.h>
   
+#include "PythonQt.h"
 QVariant PythonQtObjectPtr::evalScript(const QString& script, int start)
 {
   return PythonQt::self()->evalScript(_object, script, start);

--- a/src/PythonQtQFileImporter.h
+++ b/src/PythonQtQFileImporter.h
@@ -43,7 +43,7 @@
 //----------------------------------------------------------------------------------
 
 #include "PythonQtPythonInclude.h"
-#include <PythonQtImportFileInterface.h>
+#include "PythonQtImportFileInterface.h"
 
 //! default importer implementation using QFile to load python code
 class PythonQtQFileImporter : public PythonQtImportFileInterface {

--- a/src/PythonQtThreadSupport.h
+++ b/src/PythonQtThreadSupport.h
@@ -40,8 +40,8 @@
 //----------------------------------------------------------------------------------
 
 
-#include <PythonQtPythonInclude.h>
-#include <PythonQtSystem.h>
+#include "PythonQtPythonInclude.h"
+#include "PythonQtSystem.h"
 
 #define PYTHONQT_FULL_THREAD_SUPPORT
 


### PR DESCRIPTION
This prevents `file not found with <angled> include; use "quotes" instead` errors.