### PR TITLE
Fix crash in GC: PyTuple_SET_ITEM steals reference

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -763,6 +763,7 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   PyObject* className = PyString_FromString(enumName);
 
   PyObject* baseClasses = PyTuple_New(1);
+  Py_INCREF(&PyInt_Type);
   PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PyInt_Type);
 
   PyObject* module = PyObject_GetAttrString(parentObject, "__module__");


### PR DESCRIPTION
Py_Finalize crash is caused by references mishandling in Enums. This PR fixes the issue. 