### PR TITLE
Fix build with Python 3.8

### DIFF
--- a/build/python.prf
+++ b/build/python.prf
@@ -41,6 +41,8 @@ macx {
   # on linux, python-config is used to autodetect Python.
   # make sure that you have installed a matching python-dev package.
   
-  unix:LIBS += $$system(python$${PYTHON_VERSION}-config --ldflags)
+  system(python$${PYTHON_VERSION}-config --embed --libs) {
+    unix:LIBS += $$system(python$${PYTHON_VERSION}-config --embed --libs)
+  } else: unix:LIBS += $$system(python$${PYTHON_VERSION}-config --libs)  
   unix:QMAKE_CXXFLAGS += $$system(python$${PYTHON_VERSION}-config --includes)
 }


### PR DESCRIPTION
With Python 3.8, python3-config --libs doesn't contain the python link target.
To avoid link issues, we first test if the python config utility accepts the
'--embed' parameter and use the output when possible.

Fixes: #6 