### PR TITLE
Create dynamic properties for QObject derived classes on demand

### DIFF
--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -687,7 +687,7 @@ static int PythonQtInstanceWrapper_setattro(PyObject *obj,PyObject *name,PyObjec
     // handle dynamic properties
     if (wrapper->_obj) {
       QVariant prop = wrapper->_obj->property(attributeName);
-      if (prop.isValid()) {
+      if (prop.isValid() || wrapper->classInfo()->isQObject()) {
         QVariant v = PythonQtConv::PyObjToQVariant(value);
         if (v.isValid()) {
           wrapper->_obj->setProperty(attributeName, v);


### PR DESCRIPTION
My use case is that i want the user to be able to create a hierarchy of objects without having to call setProperty, like this:
```
ob1 = api.createSomeObj()
ob1.subobj1 = api.createSomeOtherObj()
ob1.subobj1.param = api.createParam()
...
```
I found no way of allowing this without modifying PythonQt, but imho it makes sense to allow this on QObjects (but not on other "pure" cpp objects of course). The proposed change affects the behaviour of PythonQt that in certain applications its not compatible to the old behaviour (which was to throw an AttributeError). I am willing to change the implementation in a way acceptable for you, because I would like to get the change into your repo that I dont need to maintain a modified version of PythonQt.

Alternative solutions that come to mind are:
1. Add a flag for PythonQt::init() like CreateDynamicPropertyOnDemand to enable the new behaviour
2. Add some callback mechanism to let the PythonQt user create the property on demand himself

Please let me know what you think about it and what solution would be acceptable to you.
Best,
Gregor