### PR TITLE
Fix history position in call to ScriptingConsole setHistory

### DIFF
--- a/src/gui/PythonQtScriptingConsole.h
+++ b/src/gui/PythonQtScriptingConsole.h
@@ -73,7 +73,7 @@ public Q_SLOTS:
   QStringList history() { return _history; }
 
   //! set history
-  void setHistory(const QStringList& h) { _history = h; _historyPosition = 0; }
+  void setHistory(const QStringList& h) { _history = h; _historyPosition = h.count(); }
 
   //! clear the console
   void clear();


### PR DESCRIPTION
In GUI ScriptingConsole, fix so that history position is correct after call to setHistory so that pressing up-arrow works and shows last history item.