### PR TITLE
Update __spec__ too (if existing) when setting the import path

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1680,6 +1680,20 @@ void PythonQt::overwriteSysPath(const QStringList& paths)
 void PythonQt::setModuleImportPath(PyObject* module, const QStringList& paths)
 {
   PyModule_AddObject(module, "__path__", PythonQtConv::QStringListToPyList(paths));
+#if PY_MAJOR_VERSION > 3 || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 4)
+  // Since Python 3.4 a module has a __spec__ member of type ModuleSpec which
+  // mirrors some module-specific attributes, see
+  // https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec .
+  //
+  // Python 3.9 prints an import warning "__package__ != __spec__.parent" on relative imports
+  // if we don't set the submodule_search_locations on __spec__ (this indirectly changes
+  // the value of parent)
+  PyObject* spec = PyObject_GetAttrString(module, "__spec__");
+  if (spec) {
+    PythonQt::self()->addVariable(spec, "submodule_search_locations", paths);
+    Py_DECREF(spec);
+  }
+#endif
 }
 
 void PythonQt::stdOutRedirectCB(const QString& str)


### PR DESCRIPTION
This change avoids a warning message "__package__ != __spec__.parent" (in Python 3.9) on relative imports from modules which have the import paths set with PythonQt::self()->setModuleImportPath(). Since __spec__ is meant to replicate some settings like __path__, this seems the correct solution.