### PR TITLE
Fix a C++20 compatibility issue with an unnamed struct (P1766R1)

### DIFF
--- a/src/PythonQtClassWrapper.h
+++ b/src/PythonQtClassWrapper.h
@@ -63,7 +63,7 @@ struct PythonQtDynamicClassInfo;
 //! a Python wrapper object for PythonQt wrapped classes
 //! which inherits from the Python type object to allow
 //! deriving of wrapped CPP classes from Python.
-typedef struct {
+typedef struct PythonQtClassWrapperStruct {
   PyHeapTypeObject _base;
 
   //! the additional class information that PythonQt stores for the CPP class


### PR DESCRIPTION
As a result of [P1766R1](1), `PyHeapTypeObject` can no longer be added to an unnamed `typedef struct`. On Visual Studio 2019 ≥16.6, this causes the warning C5208 in C++14 and C++17 mode, and the error C7626 with `/std:c++latest` or the future `/std:c++20`. Giving a name to the unnamed struct is the simplest fix here; see https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208.

[1]: http://wg21.link/p1766r1