### PR TITLE
Set up CI builds for different gcc versions

### DIFF
--- a/.github/workflows/Dockerfile_gcc
+++ b/.github/workflows/Dockerfile_gcc
@@ -1,0 +1,38 @@
+FROM gcc:#GCC#
+
+RUN apt-get update && apt-get install -y --force-yes \
+    unzip \
+    wget \
+    python3 \
+    python3-dev \
+    libpython3-dev \
+    qtbase5-dev \
+    qtbase5-private-dev \
+    qtchooser \
+    qt5-qmake \
+    qtbase5-dev-tools \
+    qttools5-dev \
+    qtdeclarative5-dev \
+    libqt5svg5* \
+    libqt5xmlpatterns5* \
+    libqt5multimedia5* \
+    libqt5multimediawidgets5* \
+    libqt5qml5* \
+    libqt5quickwidgets5* \
+    qtmultimedia5-dev
+RUN apt-get clean
+
+RUN mkdir -p work
+
+COPY . work/
+
+WORKDIR work
+
+ARG QT_SELECT=qt5
+RUN uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
+
+RUN qmake -r PythonQt.pro \
+    PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+    PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+
+CMD ["make"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+      
+   
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest]
+        gcc: [7, 9, 11]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup docker container
+      shell: bash
+      run: |
+        cat $GITHUB_WORKSPACE/.github/workflows/Dockerfile_gcc | sed 's/#GCC#/${{ matrix.gcc }}/' > ./Dockerfile
+        docker build -t pythonqt -f ./Dockerfile . 
+    - name: Run docker
+      run: docker run -t pythonqt


### PR DESCRIPTION
This is a first attempt to setup some CI builds, currently only building PythonQt using qmake/make using gcc 7, 9 and 11.
This just uses the GCC docker images and the Python and Qt images that are installed there (Python 3.7.3 / Qt 5.11.3 for gcc 7 and 9, Python 3.9.2 / Qt 5.15.2 for gcc 11).

Probable tasks for future PRs:
- setup Windows and Mac builds
- use specific Qt and Python version combinations
- run the created generator for a specific Qt version and provide the created code
- a bit unrelated - switch to CMake (there are already several forks who have done this)

I also tried to use gcc 5 and 6, but if just using the standard GCC docker images with the standard Python and Qt packages, they run with Python 3.4 and Qt 5.3.2, which is not supported with the current version (does not compile due to missing member functions).