### PR TITLE
Add -std=c++11 flag to check for problems

### DIFF
--- a/build/common.prf
+++ b/build/common.prf
@@ -72,3 +72,4 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
 VERSION = 3.2.0
 
 win32: CONFIG += skip_target_version_ext
+unix: QMAKE_CXXFLAGS += -std=c++11


### PR DESCRIPTION
- trying with -std=c++98 failed with a lot of various errors
- shall ensure that only C++11-compatible changes are merged for now