### PR TITLE
Add CentOS7 docker image to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,10 @@ on:
       - master
   pull_request:
       
-   
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,14 +17,13 @@ jobs:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
-        gcc: [7, 9, 11]
+        docker-image: [gcc7, gcc11, centos7]
 
     steps:
     - uses: actions/checkout@v3
     - name: Setup docker container
-      shell: bash
       run: |
-        cat $GITHUB_WORKSPACE/.github/workflows/Dockerfile_gcc | sed 's/#GCC#/${{ matrix.gcc }}/' > ./Dockerfile
-        docker build -t pythonqt -f ./Dockerfile . 
+        docker build -t pythonqt -f $GITHUB_WORKSPACE/.github/workflows/dockerfiles/Dockerfile_${{ matrix.docker-image }} . 
+
     - name: Run docker
       run: docker run -t pythonqt

--- a/.github/workflows/dockerfiles/Dockerfile_centos7
+++ b/.github/workflows/dockerfiles/Dockerfile_centos7
@@ -1,0 +1,33 @@
+FROM centos:7
+
+RUN yum update -y
+RUN yum groupinstall "Development Tools" -y
+RUN yum install -y \
+    which \
+    python3 \
+    python3-debug \
+    qt5-qtbase-* \
+    qt5-qttools* \
+    qt5-qtsvg \
+    qt5-qtsvg-devel \
+    qt5-qtxmlpatterns \
+    qt5-qtxmlpatterns-devel \
+    qt5-qtmultimedia \
+    qt5-qtmultimedia-devel \
+    qt5-qt3d \
+    qt5-qt3d-devel
+
+RUN mkdir -p work
+
+COPY . work/
+
+WORKDIR work
+
+ARG QT_SELECT=qt5
+RUN uname -a; gcc --version | grep "gcc"; python3 --version; qmake-qt5 --version
+
+RUN qmake-qt5 -r PythonQt.pro \
+    PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+    PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+
+CMD ["make"]

--- a/.github/workflows/dockerfiles/Dockerfile_gcc11
+++ b/.github/workflows/dockerfiles/Dockerfile_gcc11
@@ -1,8 +1,6 @@
-FROM gcc:#GCC#
+FROM gcc:11
 
 RUN apt-get update && apt-get install -y --force-yes \
-    unzip \
-    wget \
     python3 \
     python3-dev \
     libpython3-dev \

--- a/.github/workflows/dockerfiles/Dockerfile_gcc7
+++ b/.github/workflows/dockerfiles/Dockerfile_gcc7
@@ -1,0 +1,36 @@
+FROM gcc:7
+
+RUN apt-get update && apt-get install -y --force-yes \
+    python3 \
+    python3-dev \
+    libpython3-dev \
+    qtbase5-dev \
+    qtbase5-private-dev \
+    qtchooser \
+    qt5-qmake \
+    qtbase5-dev-tools \
+    qttools5-dev \
+    qtdeclarative5-dev \
+    libqt5svg5* \
+    libqt5xmlpatterns5* \
+    libqt5multimedia5* \
+    libqt5multimediawidgets5* \
+    libqt5qml5* \
+    libqt5quickwidgets5* \
+    qtmultimedia5-dev
+RUN apt-get clean
+
+RUN mkdir -p work
+
+COPY . work/
+
+WORKDIR work
+
+ARG QT_SELECT=qt5
+RUN uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
+
+RUN qmake -r PythonQt.pro \
+    PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+    PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+
+CMD ["make"]


### PR DESCRIPTION
- uses gcc 4.8.5, Python 3.6.8 and Qt 5.9.7
- also remove gcc 9 build (keep gcc 7 and 11)