### PR TITLE
Fix build with Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
            python-version: '3.6'
            qt-version: '5.11.*'
          - macos-version: '12'
-           python-version: '3.10'
+           python-version: '3.11'
            qt-version: '5.12.*'
     runs-on: macos-${{ matrix.macos-version }}
     steps:

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -67,6 +67,7 @@
 // .co_varnames was removed in 3.11, but the helper function was added
 #if PY_VERSION_HEX < 0x030B0000
 static inline PyObject *PyCode_GetVarnames(PyCodeObject *o) {
+  Py_XINCREF(o->co_varnames);
   return o->co_varnames;
 }
 #endif
@@ -2453,6 +2454,7 @@ QString PythonQtPrivate::getSignature(PyObject* object)
           Q_ASSERT(PyString_Check(s));
           varkeywords = PyString_AsString(s);
         }
+        Py_DECREF(co_varnames);
       }
       
       PyObject* defaultsTuple = func->func_defaults;

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -58,10 +58,17 @@
 
 #include <QDir>
 
-#if PY_MINOR_VERSION >= 10
+#if PY_VERSION_HEX >= 0x030A0000
 #include <cpython/pydebug.h>
 #else
 #include <pydebug.h>
+#endif
+
+// .co_varnames was removed in 3.11, but the helper function was added
+#if PY_VERSION_HEX < 0x030B0000
+static inline PyObject *PyCode_GetVarnames(PyCodeObject *o) {
+  return o->co_varnames;
+}
 #endif
 
 #include <vector>
@@ -2427,22 +2434,22 @@ QString PythonQtPrivate::getSignature(PyObject* object)
       //       inspect.getargs() can handle anonymous (tuple) arguments, while this code does not.
       //       It can be implemented, but it may be rarely needed and not necessary.
       PyCodeObject* code = (PyCodeObject*)func->func_code;
-      if (code->co_varnames) {
+      if (auto co_varnames = PyCode_GetVarnames(code)) {
         int nargs = code->co_argcount;
-        Q_ASSERT(PyTuple_Check(code->co_varnames));
+        Q_ASSERT(PyTuple_Check(co_varnames));
         for (int i=0; i<nargs; i++) {
-          PyObject* name = PyTuple_GetItem(code->co_varnames, i);
+          PyObject* name = PyTuple_GetItem(co_varnames, i);
           Q_ASSERT(PyString_Check(name));
           arguments << PyString_AsString(name);
         }
         if (code->co_flags & CO_VARARGS) {
-          PyObject* s = PyTuple_GetItem(code->co_varnames, nargs);
+          PyObject* s = PyTuple_GetItem(co_varnames, nargs);
           Q_ASSERT(PyString_Check(s));
           varargs = PyString_AsString(s);
           nargs += 1;
         }
         if (code->co_flags & CO_VARKEYWORDS) {
-          PyObject* s = PyTuple_GetItem(code->co_varnames, nargs);
+          PyObject* s = PyTuple_GetItem(co_varnames, nargs);
           Q_ASSERT(PyString_Check(s));
           varkeywords = PyString_AsString(s);
         }

--- a/src/PythonQtClassWrapper.h
+++ b/src/PythonQtClassWrapper.h
@@ -49,7 +49,6 @@
 #include "structmember.h"
 #include "methodobject.h"
 #include "compile.h"
-#include "eval.h"
 #include <QString>
 
 class PythonQtClassInfo;

--- a/src/PythonQtInstanceWrapper.h
+++ b/src/PythonQtInstanceWrapper.h
@@ -51,7 +51,6 @@
 #include "structmember.h"
 #include "methodobject.h"
 #include "compile.h"
-#include "eval.h"
 
 class PythonQtClassInfo;
 class QObject;

--- a/src/PythonQtSignalReceiver.cpp
+++ b/src/PythonQtSignalReceiver.cpp
@@ -45,7 +45,6 @@
 #include "PythonQtConversion.h"
 #include <QMetaObject>
 #include <QMetaMethod>
-#include "funcobject.h"
 
 // use -2 to signal that the variable is uninitialized
 int PythonQtSignalReceiver::_destroyedSignal1Id = -2;


### PR DESCRIPTION
Python 3.11 removed some fields in the PyCodeObject, [but introduced access functions](https://docs.python.org/3/c-api/code.html#c.PyCode_GetVarnames). Thus, the similarly named function is enough to fix the build issue.