### PR TITLE
CI for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
         set -eu
         PYTHON_VERSION_FULL=$(python --version 2>&1 | cut -f 2 -d ' ')
         PYTHON_VERSION_SHORT=$(cut -f 1,2 -d . <<< $PYTHON_VERSION_FULL)
-        QT_VERSION_FULL=$($Qt5_DIR/bin/qmake -query QT_VERSION)
+        QT_VERSION_FULL=$($Qt5_Dir/bin/qmake -query QT_VERSION)
         QT_VERSION_SHORT=$(cut -f 1,2 -d . <<< $QT_VERSION_FULL)
         MACOS_VERSION_FULL=$(sw_vers -productVersion)
         MACOS_VERSION_SHORT=$(cut -f 1,2 -d . <<< $MACOS_VERSION_FULL)
@@ -197,7 +197,7 @@ jobs:
         do if pkg-config --exists "$i"; then PYTHON_PKGCONFIG_NAME="$i"; break; fi; done
         qmake CONFIG+=release CONFIG+=sanitizer CONFIG+=sanitize_undefined \
         PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }} \
-        PYTHON_DIR="$pythonLocation" \
+        PYTHON_PATH="$pythonLocation" \
         PKGCONFIG+=$PYTHON_PKGCONFIG_NAME \
         -r PythonQt.pro
         make -j 2 && make check TESTARGS="-platform offscreen"
@@ -206,7 +206,7 @@ jobs:
       run: |
         cd generator
         # workaround to allow to find the Qt include dirs for installed standard qt packages
-        QTDIR=-UNDEFINED- ./pythonqt_generator --include-paths=$Qt5_DIR/lib
+        QTDIR=-UNDEFINED- ./pythonqt_generator --include-paths=$Qt5_Dir/lib
 
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
@@ -214,3 +214,112 @@ jobs:
         name: wrappers_macos${{ steps.versions.outputs.MACOS_VERSION_SHORT }}_qt${{ steps.versions.outputs.QT_VERSION_SHORT }}
         path: generated_cpp
 
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+       qt-arch: ['win64_mingw73']
+       python-version: ['3.10']
+       qt-version: ['5.12.*']
+       python-arch: ['x64']
+       pythonqtall-config: ['']
+#       msvc-toolset: ['14.0']
+       include:
+         - qt-arch: 'win64_msvc2017_64'
+           python-version: '3.6'
+           python-arch: 'x64'
+           qt-version: '5.11.*'
+#           msvc-toolset: '14.16'
+
+         - qt-arch: 'win32_mingw53'
+           python-version: '2.7'
+           python-arch: 'x86'
+           qt-version: '5.11.*'
+
+#Either MSVC2015 is sick or Qt5.9 is buggy :(
+#Main problem is QBasicMutex with default ctor, that (by no means) is missing in dll-export of QtCore, but linker tries to find it
+#         - qt-arch: 'win32_msvc2015'
+#           python-version: '2.7'
+#           python-arch: 'x86'
+#           qt-version: '5.9.*'
+#           pythonqtall-config: 'PythonQtCore PythonQtGui PythonQtMultimedia'
+
+    runs-on: windows-latest
+    steps:
+
+    - name: Checkout PythonQt
+      uses: actions/checkout@v3
+
+    - name: Reset PATH
+      uses: egor-tensin/cleanup-path@v3
+
+    - name: Install MSVC++
+      uses: ilammy/msvc-dev-cmd@v1
+      if: ${{ contains(matrix.qt-arch, 'msvc') }}
+      with:
+        arch: amd64${{ contains(matrix.python-arch, 'x86') && '_x86' || '' }}
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v3
+      with:
+        aqtversion: '==2.1.*'
+        version: ${{ matrix.qt-version }}
+        host: 'windows'
+        target: 'desktop'
+        arch: ${{ matrix.qt-arch }}
+        modules: 'qtscript'
+        archives: 'qtwinextras qtmultimedia qtbase'
+        tools: ${{ contains(matrix.qt-arch, 'mingw') && format('tools_mingw,qt.tools.{0}0', matrix.qt-arch) || '' }}
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '${{ matrix.python-version }}'
+        architecture: ${{ matrix.python-arch }}
+
+    - name: Detect exact versions
+      shell: bash
+      id: versions
+      run: |
+        set -eu
+        QT_VERSION_FULL=$("$Qt5_Dir/bin/qmake" -query QT_VERSION)
+        QT_VERSION_SHORT=$(cut -f 1,2 -d . <<< $QT_VERSION_FULL)
+        PYTHON_VERSION_FULL=$(python --version 2>&1 | cut -f 2 -d ' ')
+        PYTHON_VERSION_SHORT=$(cut -f 1,2 -d . <<< $PYTHON_VERSION_FULL)
+        echo "QT_VERSION_FULL=$QT_VERSION_FULL" | tee -a $GITHUB_OUTPUT
+        echo "QT_VERSION_SHORT=$QT_VERSION_SHORT" | tee -a $GITHUB_OUTPUT
+        echo "PYTHON_VERSION_SHORT=$PYTHON_VERSION_SHORT" | tee -a $GITHUB_OUTPUT
+
+    - name: Add Qt and MinGW to PATH
+      shell: cmd
+      run: |
+        set "ADDPATH=%Qt5_Dir%\bin"
+        ${{ contains(matrix.qt-arch, 'mingw') && format('FOR /F "tokens=1,2 delims=_" %%I IN ("{0}") DO SET "ADDPATH=%ADDPATH%;%IQTA_TOOLS%\%%J0_{1}\bin', matrix.qt-arch, contains(matrix.qt-arch, 'win32') && '32' || '64') || '' }}
+        echo PATH=%ADDPATH%;%PATH% >> %GITHUB_ENV%
+        echo CL=/MP >> $GITHUB_ENV
+
+    - name: Build PythonQt
+      shell: cmd
+      run: |
+        qmake -query
+        python --version
+        qmake CONFIG+=release CONFIG-=debug_and_release CONFIG-=debug_and_release_target ^
+           "PYTHONQTALL_CONFIG=${{ matrix.pythonqtall-config }}" ^
+           "PYTHON_PATH=%pythonLocation%" ^
+           "PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }}" ^
+           PythonQt.pro
+        mingw32-make -j 2 && mingw32-make check "TESTARGS=-platform offscreen" ^
+          || nmake && nmake check "TESTARGS=-platform offscreen"
+
+    - name: Generate Wrappers
+      shell: cmd
+      run: |
+        cd generator
+        set QTDIR=%Qt5_Dir%
+        pythonqt_generator
+
+    - name: Upload Wrappers
+      uses: actions/upload-artifact@v3
+      with:
+        name: wrappers_${{ matrix.qt-arch }}_${{ steps.versions.outputs.QT_VERSION_SHORT }}
+        path: generated_cpp

--- a/build/PythonQt.prf
+++ b/build/PythonQt.prf
@@ -12,5 +12,5 @@ CONFIG(debug, debug|release) {
 }
 
 win32-g++: LIBS += $$DESTDIR/../lib/PythonQt-Qt5-Python$${PYTHON_VERSION}$${DEBUG_EXT}.dll
-win32-msvc*: LIBS += $$DESTDIR/../lib/PythonQt-Qt5-Python$${PYTHON_VERSION}$${DEBUG_EXT}.lib
+win32-*msvc*: LIBS += $$DESTDIR/../lib/PythonQt-Qt5-Python$${PYTHON_VERSION}$${DEBUG_EXT}.lib
 unix: LIBS += -L$$DESTDIR/../lib -lPythonQt-Qt5-Python$${PYTHON_VERSION}$${DEBUG_EXT}

--- a/build/common.prf
+++ b/build/common.prf
@@ -70,7 +70,9 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
 }
 
 VERSION = 3.2.0
-
+greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 9): CONFIG += c++11
 win32: CONFIG += skip_target_version_ext
-unix: CONFIG += c++11
-gcc: QMAKE_CXXFLAGS += -Wno-deprecated-declarations
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -ansi -pedantic
+win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-unused-command-line-argument
+#Do not issue warning to system includes
+gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]

--- a/build/python.prf
+++ b/build/python.prf
@@ -6,8 +6,7 @@ isEmpty( PYTHON_VERSION ) {
   PYTHON_VERSION=$$(PYTHON_VERSION)
 }
 isEmpty( PYTHON_VERSION ) {
-  win32:PYTHON_VERSION=27
-  unix:PYTHON_VERSION=2.7
+  PYTHON_VERSION=2.7
 }
 
 isEmpty( PYTHON_DIR ) {
@@ -30,8 +29,18 @@ PYTHON_VERSION_MINOR=$$section(PYTHON_VERSION, ., 1, 1)
 # Python 2.x has problems:
 # 1) https://wiki.gentoo.org/wiki/Project:Python/Strict_aliasing
 # 2) deprecated implicit cast of string literals to char*
-equals(PYTHON_VERSION_MAJOR, 2):gcc:QMAKE_CXXFLAGS *= -fno-strict-aliasing -Wno-error=write-strings
+equals(PYTHON_VERSION_MAJOR, 2) {
+   gcc:QMAKE_CXXFLAGS *= -fno-strict-aliasing -Wno-write-strings
+   # Qt 5.4 adds this option, but this is not compatible with the Python API
+   msvc: QMAKE_CXXFLAGS -= -Zc:strictStrings
+}
+
 contains(PKGCONFIG, "python.*"){
+# If `pkg-config` is configured, use `qmake PKGCONFIG+=python3.8-embed CONFIG+=...`
+# or `PKGCONFIG+=python2.7m`-like form for older versions,
+# see `pkg-config --list-all | grep python` for details.
+# This can help with GNU/Linux (including macOS with Homebrew), MSYS2/MinGW environment,
+# and also with OpenEmbedded and other cross-builds
   CONFIG += link_pkgconfig
   PYTHON_PKGCONFIG = $$member($$unique($$find(PKGCONFIG, "python.*")), 1, 1)
   # add rpath
@@ -63,8 +72,26 @@ contains(PKGCONFIG, "python.*"){
     DEBUG_EXT = 
   }
 
-  win32:INCLUDEPATH += $$(PYTHON_PATH)/PC $$(PYTHON_PATH)/include
-  win32:LIBS += $$(PYTHON_LIB)/python$${PYTHON_VERSION}$${DEBUG_EXT}.lib
+  isEmpty(PYTHON_PATH):PYTHON_PATH=$(PYTHON_PATH)
+  isEmpty(PYTHON_PATH)|!exists("$$PYTHON_PATH\\include") | !exists("$$PYTHON_PATH\\libs\\") {
+     error("PYTHON_PATH must be set to correct folder with \\libs and \\include subfolders ")
+  }
+
+  #We need to destinguish 64-bit build to add a workaround option
+  #The only known problematic case is MinGW with external (MSVC-built) Python2
+  mingw:equals(PYTHON_VERSION_MAJOR, 2): isEmpty(QMAKE_TARGET.arch):system(\
+  $$system_quote($$system_path($${PYTHON_PATH}/python.exe)) -c \
+  $$system_quote(import sysconfig;exit(0 if 0 <= sysconfig.get_platform().find(\'win-amd64\') else 1))\
+  ):DEFINES += MS_WIN64
+
+  INCLUDEPATH += $$shell_path($${PYTHON_PATH}/include)
+
+  LIBS += $$shell_path(-L$${PYTHON_PATH}/libs)
+  LIBS += -lpython$${PYTHON_VERSION_MAJOR}$${PYTHON_VERSION_MINOR}$${DEBUG_EXT}
+
+  # Hack for "CONFIG+=testcase" and 'make check' to add python's dll to PATH
+  deppath += $$shell_path($${PYTHON_PATH})
+
 } else:unix {
   # on linux, python-config is used to autodetect Python.
   # make sure that you have installed a matching python-dev package.

--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
@@ -35,7 +35,13 @@ include ( ../../build/common.prf )
 include ( ../../build/PythonQt.prf )  
 TARGET = $$replace(TARGET, PythonXY, Python$${PYTHON_VERSION})
 
-CONFIG += dll qt
+CONFIG += qt strict_c++
+
+!static:!staticlib {
+  CONFIG += dll
+  # Force linker to complain on undefined references for dll/so/dylib build when possible
+  QMAKE_LFLAGS_SHLIB += $$QMAKE_LFLAGS_NOUNDEF
+}
 
 DEFINES += PYTHONQT_QTALL_EXPORTS
 
@@ -74,6 +80,7 @@ defineTest(Xinclude) {
 PythonQtCore {
   DEFINES += PYTHONQT_WITH_CORE
   Xinclude (com_trolltech_qt_core)
+  QT += core
 }
 
 PythonQtGui  {
@@ -85,7 +92,7 @@ PythonQtGui  {
 PythonQtSvg {
   DEFINES += PYTHONQT_WITH_SVG
   Xinclude (com_trolltech_qt_svg)
-  QT +=svg
+  QT += svg
 }
 
 PythonQtSql {

--- a/generator/generator.h
+++ b/generator/generator.h
@@ -42,10 +42,7 @@
 #ifndef GENERATOR_H
 #define GENERATOR_H
 
-#include "metajava.h"
-#include "typesystem.h"
-
-#include "codemodel.h"
+#include "abstractmetalang.h"
 
 #include <QObject>
 #include <QFile>
@@ -57,7 +54,7 @@ class Generator : public QObject
     Q_PROPERTY(QString outputDirectory READ outputDirectory WRITE setOutputDirectory)
 
 public:
-    enum Option {
+    enum Option:uint32_t {
         NoOption                 = 0x00000000,
         BoxedPrimitive           = 0x00000001,
         ExcludeConst             = 0x00000002,

--- a/generator/generator.pri
+++ b/generator/generator.pri
@@ -17,12 +17,20 @@ include($$GENERATORPATH/parser/rxx.pri)
 
 include($$GENERATORPATH/parser/rpp/rpp.pri)
 
-win32-msvc2005:{
+CONFIG += strict_c++ c++11
+win32-msvc*{
+#Disable warning C4996 (deprecated declarations)
         QMAKE_CXXFLAGS += -wd4996
         QMAKE_CFLAGS += -wd4996
+#Disable warnings for external headers
+	greaterThan(QMAKE_MSC_VER, 1599):QMAKE_CXXFLAGS += -external:anglebrackets -external:W0 -external:templates-
 }
-gcc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wpedantic
-clang: QMAKE_CXXFLAGS += -Wno-nested-anon-types -Wno-gnu-anonymous-struct -Wno-unused-private-field
+#Do not issue warning to Qt's system includes
+gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -pedantic -ansi -Winit-self -Wuninitialized
+clang|win32-clang-msvc: QMAKE_CXXFLAGS += -Wno-nested-anon-types -Wno-gnu-anonymous-struct -Wno-unused-private-field
+win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-language-extension-token -Wno-microsoft-enum-value
+
 
 # Input
 HEADERS += \

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -40,7 +40,6 @@
 ****************************************************************************/
 
 #include "shellheadergenerator.h"
-#include "fileout.h"
 
 #include <QtCore/QDir>
 
@@ -156,7 +155,6 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       s << "};" << endl;
     }
     s << endl;
-    const AbstractMetaClass* c = meta_class;
     s << "   ~" << shellClassName(meta_class) << "()" << (meta_class->hasVirtualDestructor() ? " override" : "") << ";" << endl;
     s << endl;
 

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -176,7 +176,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
           s << "        }" << endl;
           s << "      }" << endl;
         }
-        s << "      if (result) { Py_DECREF(result); } " << endl;
+        s << "      if (result) { Py_DECREF(result); }" << endl;
         s << "      Py_DECREF(obj);" << endl;
         // ugly hack, we don't support QGraphicsScene* nor QGraphicsItem* QVariants in PythonQt...
         if (fun->name() == "itemChange" && fun->type() && fun->type()->isVariant()) {

--- a/src/src.pri
+++ b/src/src.pri
@@ -4,14 +4,15 @@ INCLUDEPATH += $$PWD
 
 CONFIG += c++11
 
-gcc:!no_warn {
-    !clang:QMAKE_CXXFLAGS += -Werror -Wno-error=missing-field-initializers
-    clang:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized
-}
+gcc:!no_warn:!clang:QMAKE_CXXFLAGS += -Wno-error=missing-field-initializers
+*-clang*:!no_warn:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized
 
 # This was needed to work around "number of sections exceeded object file format limit" linker error
 win32-msvc*:QMAKE_CXXFLAGS += /bigobj
-win32-g++: QMAKE_CXXFLAGS += -Wa,-mbig-obj
+!ltcg:win32-g++: QMAKE_CXXFLAGS += -Wa,-mbig-obj
+
+# Force linker to complain on undefined references for dll/so/dylib build when possible
+QMAKE_LFLAGS_SHLIB += $$QMAKE_LFLAGS_NOUNDEF
 
 HEADERS +=                    \
   $$PWD/PythonQt.h                  \

--- a/src/src.pro
+++ b/src/src.pro
@@ -7,13 +7,10 @@
 TARGET   = PythonQt-Qt5-PythonXY
 TEMPLATE = lib
 
-
 DESTDIR    = ../lib
 
 CONFIG += qt
 CONFIG -= flat
-
-mingw:QMAKE_CXXFLAGS+=-Wa,-mbig-obj
 
 # allow to choose static linking through the environment variable PYTHONQT_STATIC
 isEmpty(PYTHONQT_STATIC) {
@@ -31,9 +28,6 @@ DEFINES += PYTHONQT_CATCH_ALL_EXCEPTIONS
 contains(QT_MAJOR_VERSION, 5) {
   QT += widgets core-private
 }
-
-# Qt 5.4 adds this option, but this is not compatible with the Python API
-QMAKE_CXXFLAGS_RELEASE -= -Zc:strictStrings
  
 INCLUDEPATH += $$PWD
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -17,7 +17,7 @@ mingw: TEST_TARGET_DIR = .
 
 DEFINES += QT_NO_CAST_TO_ASCII
 
-gcc: QMAKE_CXXFLAGS += -Wpedantic
+gcc: QMAKE_CXXFLAGS += -pedantic -ansi -Winit-self -Wuninitialized
 
 contains(QT_MAJOR_VERSION, 5) {
   QT += widgets


### PR DESCRIPTION
* Initial CI for Windows via GHA with `make check` to run unit-tests
* Basic `clang-msvc` support
* Fixes for `msvc` and `mingw`
* Support for LTO (`CONFIG+=ltcg`) builds on all platforms
* Minor code improvements, including build scripts unification