### PR TITLE
Fix crash when using QObject::disconnect method

### DIFF
--- a/src/PythonQtSignalReceiver.h
+++ b/src/PythonQtSignalReceiver.h
@@ -94,7 +94,7 @@ private:
   int       _signalId;
   int       _slotId;
   const PythonQtMethodInfo* _methodInfo;
-  PythonQtObjectPtr _callable;
+  PythonQtSafeObjectPtr _callable;
 };
 
 //! base class for signal receivers


### PR DESCRIPTION
 (when multi-threading is enabled)

It seems this is done with a slot call, which gives up the GIL, but the GIL is needed in the destructor of the PythonQtSignalReceiver when a callable target was given. Fix this by simply using a PythonQtSafeObjectPtr for the _callable.