### PR TITLE
Revert undefining some defines

### DIFF
--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -33,19 +33,6 @@
 #ifndef __PythonQtPythonInclude_h
 #define __PythonQtPythonInclude_h
 
-// Undefine macros that Python.h defines to avoid redefinition warning.
-#ifdef _POSIX_C_SOURCE
-#  undef _POSIX_C_SOURCE
-#endif
-
-#ifdef _POSIX_THREADS
-#  undef _POSIX_THREADS
-#endif
-
-#ifdef _XOPEN_SOURCE
-#  undef _XOPEN_SOURCE
-#endif
-
 // Undefine Qt keywords that conflict with Python headers
 #ifdef slots
 #undef slots


### PR DESCRIPTION
- this has been introduced in #89 and breaks builds including *PythonQt.h*

The reverted code undefines `_POSIX_THREADS` (and a couple of other defines), which are queried in *PythonQt.h*.
If it is not set on a POSIX system, we get the error:
```Require native threads. See https://bugs.python.org/issue31370```

As far as I can see, none of these defines comes from *python.h*, at least not in current versions of Python.
