### PR TITLE
CI runners clean-up 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,15 +82,21 @@ jobs:
         name: wrappers_ubuntu_22_04
         path: generated_cpp
 
-  centos:
+  oldschool:
     strategy:
       fail-fast: false
       matrix:
-        container:
-        - 'centos:7'
+        container_os: ['centos']
+        container_os_version: ['7']
+        container_os_python_package: ['python-debug']
         configuration: ['debug', 'release']
+        include:
+          - container_os: 'rockylinux'
+            container_os_version: '9'
+            container_os_python_package: 'python3-devel'
+            configuration: 'release'
     runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
+    container: '${{ matrix.container_os }}:${{ matrix.container_os_version }}'
     steps:
     - name: Install Qt
       run: |
@@ -98,7 +104,7 @@ jobs:
         yum groupinstall "Development Tools" -y
         yum install -y \
         which \
-        python-debug \
+        ${{ matrix.container_os_python_package }} \
         qt5-qtbase-* \
         qt5-qttools* \
         qt5-qtsvg \
@@ -114,64 +120,12 @@ jobs:
       run: |
         export QT_SELECT=qt5
         echo ======= SYSTEM INFO ========
-        uname -a; gcc --version | grep "gcc"; python --version; qmake-qt5 --version
+        which python 2>/dev/null && export PYTHON_VERSION_SUFFIX= || export PYTHON_VERSION_SUFFIX=3
+        uname -a; gcc --version | grep "gcc"; python${PYTHON_VERSION_SUFFIX} --version; qmake-qt5 --version
         echo ============================
         qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} \
-          PYTHON_VERSION=$(python --version | cut -d " " -f 2 | cut -d "." -f1,2) \
-          PYTHON_DIR=$(which python | xargs dirname | xargs dirname)
-        make -j 2 && make check TESTARGS="-platform offscreen"
-      
-    - name: Generate Wrappers
-      run: |
-        # workaround to allow to find the Qt include dirs for installed standard qt packages
-        mkdir /usr/include/qt5ln; ln -s /usr/include/qt5 /usr/include/qt5ln/include
-        export QTDIR=/usr/include/qt5ln
-        cd generator
-        ./pythonqt_generator
-        
-    - name: Upload Wrappers
-      uses: actions/upload-artifact@v3
-      with:
-        name: wrappers_centos7_${{ matrix.configuration }}
-        path: generated_cpp
-
-  rockylinux:
-    strategy:
-      fail-fast: false
-      matrix:
-        container:
-          - 'rockylinux:9'
-        configuration: ['debug', 'release']
-    runs-on: ubuntu-latest
-    container: ${{ matrix.container }}
-    steps:
-    - name: Install Qt
-      run: |
-        yum update -y
-        yum groupinstall "Development Tools" -y
-        yum install -y \
-        which \
-        python3-devel \
-        qt5-qtbase-* \
-        qt5-qttools* \
-        qt5-qtsvg \
-        qt5-qtxmlpatterns \
-        qt5-qtmultimedia \
-        qt5-qt3d \
-        qt5-*-devel
-
-    - name: Checkout PythonQt
-      uses: actions/checkout@v3
-
-    - name: Build PythonQt
-      run: |
-        export QT_SELECT=qt5
-        echo ======= SYSTEM INFO ========
-        uname -a; gcc --version | grep "gcc"; python3 --version; qmake-qt5 --version
-        echo ============================
-        qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} \
-          PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
-          PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+          PYTHON_VERSION=$(python${PYTHON_VERSION_SUFFIX} --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+          PYTHON_DIR=$(which python${PYTHON_VERSION_SUFFIX} | xargs dirname | xargs dirname)
         make -j 2 && make check TESTARGS="-platform offscreen"
 
     - name: Generate Wrappers
@@ -185,7 +139,7 @@ jobs:
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
       with:
-        name: wrappers_rockylinux9_${{ matrix.configuration }}
+        name: wrappers_${{ matrix.container_os }}-${{ matrix.container_os_version }}_${{ matrix.configuration }}
         path: generated_cpp
 
   macOS:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,7 @@ jobs:
 #           msvc-toolset: '14.16'
 
          - qt-arch: 'win32_mingw53'
-           python-version: '2.7'
+           python-version: '3.8'
            python-arch: 'x86'
            qt-version: '5.11.*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
 #           msvc-toolset: '14.16'
 
          - qt-arch: 'win32_mingw53'
-           python-version: '3.8'
+           python-version: '3.6'
            python-arch: 'x86'
            qt-version: '5.11.*'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,14 +193,10 @@ jobs:
       fail-fast: false
       matrix:
        macos-version:  ['11']
-       python-version: ['2.7']
+       python-version: ['3.6']
        qt-version: ['5.9.*']
        configuration: ['release','debug']
        include:
-         - macos-version: '11'
-           python-version: '3.6'
-           qt-version: '5.11.*'
-           configuration: 'release'
          - macos-version: '12'
            python-version: '3.11'
            qt-version: '5.12.*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       macos-version:  ['10.15']
+       macos-version:  ['11']
        python-version: ['2.7']
        qt-version: ['5.9.*']
        configuration: ['release','debug']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
       with:
-        name: wrappers_${{ matrix.container }}_${{ matrix.configuration }}
+        name: wrappers_centos7_${{ matrix.configuration }}
         path: generated_cpp
 
   rockylinux:
@@ -185,7 +185,7 @@ jobs:
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
       with:
-        name: wrappers_${{ matrix.container }}_${{ matrix.configuration }}
+        name: wrappers_rockylinux9_${{ matrix.configuration }}
         path: generated_cpp
 
   macOS:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,60 @@ jobs:
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
       with:
-        name: wrappers_centos7
+        name: wrappers_${{ matrix.container }}_${{ matrix.configuration }}
+        path: generated_cpp
+
+  rockylinux:
+    strategy:
+      fail-fast: false
+      matrix:
+        container:
+          - 'rockylinux:9'
+        configuration: ['debug', 'release']
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    steps:
+    - name: Install Qt
+      run: |
+        yum update -y
+        yum groupinstall "Development Tools" -y
+        yum install -y \
+        which \
+        python3-devel \
+        qt5-qtbase-* \
+        qt5-qttools* \
+        qt5-qtsvg \
+        qt5-qtxmlpatterns \
+        qt5-qtmultimedia \
+        qt5-qt3d \
+        qt5-*-devel
+
+    - name: Checkout PythonQt
+      uses: actions/checkout@v3
+
+    - name: Build PythonQt
+      run: |
+        export QT_SELECT=qt5
+        echo ======= SYSTEM INFO ========
+        uname -a; gcc --version | grep "gcc"; python3 --version; qmake-qt5 --version
+        echo ============================
+        qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} \
+          PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+          PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+        make -j 2 && make check TESTARGS="-platform offscreen"
+
+    - name: Generate Wrappers
+      run: |
+        # workaround to allow to find the Qt include dirs for installed standard qt packages
+        mkdir /usr/include/qt5ln; ln -s /usr/include/qt5 /usr/include/qt5ln/include
+        export QTDIR=/usr/include/qt5ln
+        cd generator
+        ./pythonqt_generator
+
+    - name: Upload Wrappers
+      uses: actions/upload-artifact@v3
+      with:
+        name: wrappers_${{ matrix.container }}_${{ matrix.configuration }}
         path: generated_cpp
 
   macOS:


### PR DESCRIPTION
1. macOS 10.15 was removed from GHA long ago.
https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
2. Python 2.7 is obsolete, thus removed for Windows and macOS, but still in CentOS7
3. RockyLinux9 is here for CI from now on