### PR TITLE
Qt6 fixes (generator code)

### DIFF
--- a/build/common.prf
+++ b/build/common.prf
@@ -70,9 +70,8 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
 }
 
 VERSION = 3.2.0
-greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 9): CONFIG += c++11
 win32: CONFIG += skip_target_version_ext
-gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -ansi -pedantic
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -pedantic
 win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-unused-command-line-argument
 #Do not issue warning to system includes
 gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -91,7 +91,7 @@ void Generator::printClasses()
         if (!shouldGenerate(cls))
             continue;
         write(s, cls);
-        s << endl << endl;
+        s << Qt::endl << Qt::endl;
     }
 }
 

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -61,7 +61,7 @@ void Generator::generate()
         return;
     }
 
-    qStableSort(m_classes);
+    std::stable_sort(m_classes.begin(), m_classes.end());
 
     foreach (AbstractMetaClass *cls, m_classes) {
         if (!shouldGenerate(cls))
@@ -85,7 +85,7 @@ void Generator::printClasses()
     QTextStream s(stdout);
 
     AbstractMetaClassList classes = m_classes;
-    qSort(classes);
+    std::sort(classes.begin(), classes.end());
 
     foreach (AbstractMetaClass *cls, classes) {
         if (!shouldGenerate(cls))

--- a/generator/generator.pri
+++ b/generator/generator.pri
@@ -17,7 +17,7 @@ include($$GENERATORPATH/parser/rxx.pri)
 
 include($$GENERATORPATH/parser/rpp/rpp.pri)
 
-CONFIG += strict_c++ c++11
+CONFIG += strict_c++
 win32-msvc*{
 #Disable warning C4996 (deprecated declarations)
         QMAKE_CXXFLAGS += -wd4996
@@ -27,7 +27,7 @@ win32-msvc*{
 }
 #Do not issue warning to Qt's system includes
 gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
-gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -pedantic -ansi -Winit-self -Wuninitialized
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -pedantic -Winit-self -Wuninitialized
 clang|win32-clang-msvc: QMAKE_CXXFLAGS += -Wno-nested-anon-types -Wno-gnu-anonymous-struct -Wno-unused-private-field
 win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-language-extension-token -Wno-microsoft-enum-value
 

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -110,7 +110,8 @@ int main(int argc, char *argv[])
         FileOut::license = true;
 
     if (args.contains("rebuild-only")) {
-        QStringList classes = args.value("rebuild-only").split(",", QString::SkipEmptyParts);
+        QStringList classes = args.value("rebuild-only").split(
+                ",", TypeDatabase::skipEmptyParts);
         TypeDatabase::instance()->setRebuildClasses(classes);
     }
 

--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -216,7 +216,7 @@ QString TypeInfo::toString() const
   return tmp;
 }
 
-bool TypeInfo::operator==(const TypeInfo &other)
+bool TypeInfo::operator==(const TypeInfo &other) const
 {
   if (arrayElements().count() != other.arrayElements().count())
     return false;

--- a/generator/parser/codemodel.h
+++ b/generator/parser/codemodel.h
@@ -154,8 +154,8 @@ struct TypeInfo
   void setArguments(const QList<TypeInfo> &arguments);
   void addArgument(const TypeInfo &arg) { m_arguments.append(arg); }
 
-  bool operator==(const TypeInfo &other);
-  bool operator!=(const TypeInfo &other) { return !(*this==other); }
+  bool operator==(const TypeInfo &other) const;
+  bool operator!=(const TypeInfo &other) const { return !(*this==other); }
 
   // ### arrays and templates??
 
@@ -171,7 +171,7 @@ private:
 	uint m_reference: 1;
 	uint m_functionPointer: 1;
 	uint m_indirections: 6;
-	inline bool equals(TypeInfo_flags other) {
+	inline bool equals(TypeInfo_flags other) const {
          return m_constant == other.m_constant
              && m_volatile == other.m_volatile
              && m_reference == other.m_reference
@@ -501,7 +501,7 @@ private:
   CodeModel::AccessPolicy _M_accessPolicy;
   union
   {
-    struct
+    struct 
     {
       uint _M_isConstant: 1;
       uint _M_isVolatile: 1;

--- a/generator/parser/codemodel.h
+++ b/generator/parser/codemodel.h
@@ -501,6 +501,9 @@ private:
   CodeModel::AccessPolicy _M_accessPolicy;
   union
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+    /* This is an anonymous struct, not allowed in C++ (it works in G++): */
     struct 
     {
       uint _M_isConstant: 1;
@@ -512,6 +515,7 @@ private:
       uint _M_isExtern: 1;
       uint _M_isMutable: 1;
     };
+#pragma GCC diagnostic pop
     uint _M_flags;
   };
 
@@ -569,6 +573,9 @@ private:
   QString _M_exception;
   union
   {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+    /* This is an anonymous struct, not allowed in C++ (it works in G++): */
     struct
     {
       uint _M_isVirtual: 1;
@@ -578,6 +585,7 @@ private:
       uint _M_isVariadics: 1;
       uint _M_isInvokable : 1; // Qt
     };
+#pragma GCC diagnostic pop
     uint _M_flags;
   };
 

--- a/generator/parser/codemodel_pointer.h
+++ b/generator/parser/codemodel_pointer.h
@@ -123,15 +123,15 @@ private:
 
 #   if QT_VERSION >= 0x050000
     operator T * () const {
-        return QAtomicPointer<T>::load();
+        return QAtomicPointer<T>::loadRelaxed();
     }
     inline bool operator!() const { return !(bool)*this; }
     operator bool () const {
-        return (bool)QAtomicPointer<T>::load();
+        return (bool)QAtomicPointer<T>::loadRelaxed();
     }
 
-    inline T *operator->() { return QAtomicPointer<T>::load(); }
-    inline const T *operator->() const { return QAtomicPointer<T>::load(); }
+    inline T *operator->() { return QAtomicPointer<T>::loadRelaxed(); }
+    inline const T *operator->() const { return QAtomicPointer<T>::loadRelaxed(); }
     inline bool operator==(const CodeModelPointer<T> &other) const { return (T*)*this == (T*)other; }
     inline bool operator!=(const CodeModelPointer<T> &other) const { return (T*)*this != (T*)other; }
     inline bool operator==(const T *ptr) const { return (T*)*this == ptr; }

--- a/generator/parser/compiler_utils.h
+++ b/generator/parser/compiler_utils.h
@@ -48,7 +48,6 @@
 #include "codemodel.h"
 
 class QString;
-class QStringList;
 struct TypeSpecifierAST;
 struct DeclaratorAST;
 class TokenStream;

--- a/generator/parser/rpp/pp-macro.h
+++ b/generator/parser/rpp/pp-macro.h
@@ -57,12 +57,16 @@ struct pp_macro
   {
     int unsigned state;
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+    /* This is an anonymous struct, not allowed in C++ (it works in G++): */
     struct
     {
       int unsigned hidden: 1;
       int unsigned function_like: 1;
       int unsigned variadics: 1;
     };
+#pragma GCC diagnostic pop
   };
 
   int lines;

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -113,7 +113,7 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
     CodeSnipList code_snips = cls->typeEntry()->codeSnips();
     for (const CodeSnip &cs :  code_snips) {
       if (cs.language == TypeSystem::PyWrapperOperators) {
-        QStringList values = cs.code().split(" ", QString::SkipEmptyParts);
+        QStringList values = cs.code().split(" ", TypeDatabase::skipEmptyParts);
         for (QString value :  values) {
           r.insert(value);
         }

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1768,7 +1768,7 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
         const QString line = lines.takeFirst().trimmed();
         if (line.isEmpty()) {
             if (!lastEmpty)
-                s << endl;
+                s << Qt::endl;
             lastEmpty = true;
             continue;
         } else {
@@ -1781,23 +1781,23 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
             s << indentor;
             if (line.startsWith("*"))
                 s << " ";
-            s << line << endl;
+            s << line << Qt::endl;
             if (line.endsWith("*/"))
                 multilineComment = false;
         } else if (line.startsWith("}")) {
             return line;
         } else if (line.endsWith("}")) {
-            s << indentor << line << endl;
+            s << indentor << line << Qt::endl;
             return 0;
         } else if(line.endsWith("{")) {
-            s << indentor << line << endl;
+            s << indentor << line << Qt::endl;
             QString tmp;
             {
                 Indentation indent(indentor);
                 tmp = formattedCodeHelper(s, indentor, lines);
             }
             if (!tmp.isNull()) {
-                s << indentor << tmp << endl;
+                s << indentor << tmp << Qt::endl;
             }
             lastLine = tmp;
             continue;
@@ -1811,7 +1811,7 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
                 !lastLine.endsWith("}") &&
                 !line.startsWith("{"))
                 s << "    ";
-            s << line << endl;
+            s << line << Qt::endl;
         }
         lastLine = line;
     }
@@ -1825,7 +1825,7 @@ QTextStream &CodeSnip::formattedCode(QTextStream &s, Indentor &indentor) const
     while (!lst.isEmpty()) {
         QString tmp = formattedCodeHelper(s, indentor, lst);
         if (!tmp.isNull()) {
-            s << indentor << tmp << endl;
+            s << indentor << tmp << Qt::endl;
         }
     }
     s.flush();

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -1151,6 +1151,18 @@ public:
         m_suppressedWarnings.append(s);
     }
 
+    /* QString::SkipEmptyParts was moved to Qt::SplitBehavior in 15.4 and the
+     * QString original as deprecated then it was removed in Qt6.  This
+     * provides compatibility with versions of Qt prior to 15.4:
+     */
+#   if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+        static const constexpr Qt::SplitBehavior skipEmptyParts =
+            Qt::SkipEmptyParts;
+#   else
+        static const  constexpr QString::SplitBehavior skipEmptyParts =
+            QString::SkipEmptyParts;
+#   endif
+
     bool isSuppressedWarning(const QString &s)
     {
         if (!m_suppressWarnings)
@@ -1159,7 +1171,8 @@ public:
         foreach (const QString &_warning, m_suppressedWarnings) {
             QString warning(QString(_warning).replace("\\*", "&place_holder_for_asterisk;"));
 
-            QStringList segs = warning.split("*", QString::SkipEmptyParts);
+            QStringList segs = warning.split("*", skipEmptyParts);
+
             if (segs.size() == 0)
                 continue ;
 

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,8 +2,6 @@ DEFINES +=  PYTHONQT_EXPORTS
 
 INCLUDEPATH += $$PWD
 
-CONFIG += c++11
-
 gcc:!no_warn:!clang:QMAKE_CXXFLAGS += -Wno-error=missing-field-initializers
 *-clang*:!no_warn:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -17,7 +17,7 @@ mingw: TEST_TARGET_DIR = .
 
 DEFINES += QT_NO_CAST_TO_ASCII
 
-gcc: QMAKE_CXXFLAGS += -pedantic -ansi -Winit-self -Wuninitialized
+gcc: QMAKE_CXXFLAGS += -pedantic -Winit-self -Wuninitialized
 
 QT += widgets
 


### PR DESCRIPTION
These commits fix a number of cases where PythonQt is using features that were obsolete in QT 5.15 LTS.  This is just in the "generator" code - I can't get a build to get any further than generator/parser/parser.cpp yet so there will be other deprecated (and not removed) cases later in the build.

At this point parser.cpp fails to build because Qt6 did a rewrite of QtXml and removed all the "SAX" classes.  It looks like rewriting parser.cpp to match could be done blind and would work in earlier versions as the Qt6 recommendation is to use a class (QXmlStreamReader) which has existed since Qt 4.3.  Unfortunately its a rewrite and I'm not happy trying that; I don't know anything about the schema being used for one thing!

So I might try using Qt5Compat as a temporary fix to avoid the rewrite and see if further progress is possible without major or incompatible (with Qt5.15) changes.