### PR TITLE
Qt6: initial changes to make compilation work

### DIFF
--- a/build/common.prf
+++ b/build/common.prf
@@ -70,9 +70,8 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
 }
 
 VERSION = 3.2.0
-greaterThan(QT_MAJOR_VERSION, 5) | greaterThan(QT_MINOR_VERSION, 9): CONFIG += c++11
 win32: CONFIG += skip_target_version_ext
-gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -ansi -pedantic
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -Wuninitialized -Winit-self -pedantic
 win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-unused-command-line-argument
 #Do not issue warning to system includes
 gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]

--- a/generator/generator.pri
+++ b/generator/generator.pri
@@ -17,7 +17,7 @@ include($$GENERATORPATH/parser/rxx.pri)
 
 include($$GENERATORPATH/parser/rpp/rpp.pri)
 
-CONFIG += strict_c++ c++11
+CONFIG += strict_c++
 win32-msvc*{
 #Disable warning C4996 (deprecated declarations)
         QMAKE_CXXFLAGS += -wd4996
@@ -27,7 +27,7 @@ win32-msvc*{
 }
 #Do not issue warning to Qt's system includes
 gcc:!isEmpty(QT_INSTALL_HEADERS): QMAKE_CXXFLAGS += -isystem $$[QT_INSTALL_HEADERS]
-gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -pedantic -ansi -Winit-self -Wuninitialized
+gcc|win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-deprecated-declarations -pedantic -Winit-self -Wuninitialized
 clang|win32-clang-msvc: QMAKE_CXXFLAGS += -Wno-nested-anon-types -Wno-gnu-anonymous-struct -Wno-unused-private-field
 win32-clang-msvc:QMAKE_CXXFLAGS += -Wno-language-extension-token -Wno-microsoft-enum-value
 

--- a/generator/parser/compiler_utils.h
+++ b/generator/parser/compiler_utils.h
@@ -48,7 +48,6 @@
 #include "codemodel.h"
 
 class QString;
-class QStringList;
 struct TypeSpecifierAST;
 struct DeclaratorAST;
 class TokenStream;

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,8 +2,6 @@ DEFINES +=  PYTHONQT_EXPORTS
 
 INCLUDEPATH += $$PWD
 
-CONFIG += c++11
-
 gcc:!no_warn:!clang:QMAKE_CXXFLAGS += -Wno-error=missing-field-initializers
 *-clang*:!no_warn:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -17,7 +17,7 @@ mingw: TEST_TARGET_DIR = .
 
 DEFINES += QT_NO_CAST_TO_ASCII
 
-gcc: QMAKE_CXXFLAGS += -pedantic -ansi -Winit-self -Wuninitialized
+gcc: QMAKE_CXXFLAGS += -pedantic -Winit-self -Wuninitialized
 
 QT += widgets
 


### PR DESCRIPTION
This is a minimalist set to pass the build tests (though I don't know about the 'nmake not found' failure).  It just fixes the multiple definitions of the compiler standard and the QStringList typedef problem.