### PR TITLE
Replace deprecated QAtomicPointer<T>::load()

### DIFF
--- a/generator/parser/codemodel_pointer.h
+++ b/generator/parser/codemodel_pointer.h
@@ -122,16 +122,22 @@ private:
 
 
 #   if QT_VERSION >= 0x050000
+#       if QT_VERSION >= QT_VERSION_CHECK(5,14,0)
+#           define LOAD loadRelaxed
+#       else
+#           define LOAD load
+#       endif
     operator T * () const {
-        return QAtomicPointer<T>::load();
+        return QAtomicPointer<T>::LOAD();
     }
     inline bool operator!() const { return !(bool)*this; }
     operator bool () const {
-        return (bool)QAtomicPointer<T>::load();
+        return (bool)QAtomicPointer<T>::LOAD();
     }
 
-    inline T *operator->() { return QAtomicPointer<T>::load(); }
-    inline const T *operator->() const { return QAtomicPointer<T>::load(); }
+    inline T *operator->() { return QAtomicPointer<T>::LOAD(); }
+    inline const T *operator->() const { return QAtomicPointer<T>::LOAD(); }
+#undef  LOAD
     inline bool operator==(const CodeModelPointer<T> &other) const { return (T*)*this == (T*)other; }
     inline bool operator!=(const CodeModelPointer<T> &other) const { return (T*)*this != (T*)other; }
     inline bool operator==(const T *ptr) const { return (T*)*this == ptr; }


### PR DESCRIPTION
This function was deprecated in Qt 5.14 then removed in Qt6, along with 'store()'.  The deprecated function information in Qt 5.15LTS says to use 'loadRelaxed', most likely on the basis that 'load' didn't guarantee better memory ordering that relaxed provides (see the standard c++ explanations of std::memory_order_relaxed etc).