### PR TITLE
Qt6: QList<T>operator== requires const T::operator==

### DIFF
--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -216,7 +216,7 @@ QString TypeInfo::toString() const
   return tmp;
 }
 
-bool TypeInfo::operator==(const TypeInfo &other)
+bool TypeInfo::operator==(const TypeInfo &other) const
 {
   if (arrayElements().count() != other.arrayElements().count())
     return false;

--- a/generator/parser/codemodel.h
+++ b/generator/parser/codemodel.h
@@ -154,8 +154,8 @@ struct TypeInfo
   void setArguments(const QList<TypeInfo> &arguments);
   void addArgument(const TypeInfo &arg) { m_arguments.append(arg); }
 
-  bool operator==(const TypeInfo &other);
-  bool operator!=(const TypeInfo &other) { return !(*this==other); }
+  bool operator==(const TypeInfo &other) const;
+  bool operator!=(const TypeInfo &other) const { return !(*this==other); }
 
   // ### arrays and templates??
 
@@ -171,7 +171,7 @@ private:
 	uint m_reference: 1;
 	uint m_functionPointer: 1;
 	uint m_indirections: 6;
-	inline bool equals(TypeInfo_flags other) {
+	inline bool equals(TypeInfo_flags other) const {
          return m_constant == other.m_constant
              && m_volatile == other.m_volatile
              && m_reference == other.m_reference


### PR DESCRIPTION
This causes a g++ compile error in codemodel.cpp (the error message is extremely confusing).  It "works" in Qt5 but adding the "const" in the relevant places does not break the compile.  Therefore:

bool TypeInfo::operator==(const TypeInfo&)

does not modify the LHS; this means that adding the const is safe (there would be a compile error if somoething in the implementation did modify part of the LHS).

It makes sense to me that Qt6 would do something to prevent an == operator with a mutable LHS.  So far as I can see QList would have to make a complete copy of the LHS under some circumstances resulting in a potentially significant performance hit (depending on the complexity of the type involved).

This is a harmless but possibly beneficial change to both 'master' and 'qt6' branches.