### PR TITLE
Qt6: qSort and qStableSort removed

### DIFF
--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -39,6 +39,7 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::stable_sort, std::sort
 #include "generator.h"
 #include "reporthandler.h"
 #include "fileout.h"

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -61,7 +61,7 @@ void Generator::generate()
         return;
     }
 
-    qStableSort(m_classes);
+    std::stable_sort(m_classes.begin(), m_classes.end());
 
     foreach (AbstractMetaClass *cls, m_classes) {
         if (!shouldGenerate(cls))
@@ -85,7 +85,7 @@ void Generator::printClasses()
     QTextStream s(stdout);
 
     AbstractMetaClassList classes = m_classes;
-    qSort(classes);
+    std::sort(classes.begin(), classes.end());
 
     foreach (AbstractMetaClass *cls, classes) {
         if (!shouldGenerate(cls))


### PR DESCRIPTION
The suggested replacements are std::stable_sort and std::sort which work (compile) in both Qt5 (5.15LTS) and Qt6.