### PR TITLE
Qt6: qSort, toList and fromList removal

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "abstractmetabuilder.h"
 #include "reporthandler.h"
 
@@ -384,7 +386,7 @@ static bool class_less_than(AbstractMetaClass *a, AbstractMetaClass *b)
 
 void AbstractMetaBuilder::sortLists()
 {
-   qSort(m_meta_classes.begin(), m_meta_classes.end(), class_less_than);
+   std::sort(m_meta_classes.begin(), m_meta_classes.end(), class_less_than);
    for (AbstractMetaClass *cls :  m_meta_classes) {
         cls->sortFunctions();
    }
@@ -971,7 +973,7 @@ AbstractMetaEnum *AbstractMetaBuilder::traverseEnum(EnumModelItem enum_item, Abs
         meta_enum->addEnumValue(meta_enum_value);
 
         ReportHandler::debugFull("   - " + meta_enum_value->name() + " = "
-                                 + meta_enum_value->value());
+                                 + QString::number(meta_enum_value->value()));
 
         // Add into global register...
         if (enclosing)
@@ -1444,7 +1446,13 @@ void AbstractMetaBuilder::traverseEnums(ScopeModelItem scope_item, AbstractMetaC
 {
     EnumList enums = scope_item->enums();
     for (EnumModelItem enum_item :  enums) {
-        AbstractMetaEnum *meta_enum = traverseEnum(enum_item, meta_class, QSet<QString>::fromList(enumsDeclarations));
+        AbstractMetaEnum *meta_enum = traverseEnum(enum_item, meta_class,
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+            QSet<QString>::fromList(enumsDeclarations)
+#else
+            QSet<QString>(enumsDeclarations.begin(), enumsDeclarations.end())
+#endif
+        );
         if (meta_enum) {
             meta_enum->setOriginalAttributes(meta_enum->attributes());
             meta_class->addEnum(meta_enum);
@@ -2461,7 +2469,7 @@ AbstractMetaClassList AbstractMetaBuilder::classesTopologicalSorted() const
     AbstractMetaClassList res;
 
     AbstractMetaClassList classes = m_meta_classes;
-    qSort(classes);
+    std::sort(classes.begin(), classes.end());
 
     QSet<AbstractMetaClass*> noDependency;
     QHash<AbstractMetaClass*, QSet<AbstractMetaClass* >* > hash;

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "abstractmetalang.h"
 #include "reporthandler.h"
 
@@ -972,7 +974,7 @@ AbstractMetaFunctionList AbstractMetaClass::virtualOverrideFunctions() const
 
 void AbstractMetaClass::sortFunctions()
 {
-    qSort(m_functions.begin(), m_functions.end(), function_sorter);
+    std::sort(m_functions.begin(), m_functions.end(), function_sorter);
 }
 
 void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
@@ -1090,7 +1092,7 @@ void AbstractMetaClass::addFunction(AbstractMetaFunction *function)
     if (!function->isDestructor()) {
         m_functions << function;
         // seems like this is not needed and takes a lot of performance
-        //qSort(m_functions.begin(), m_functions.end(), function_sorter);
+        //std::sort(m_functions.begin(), m_functions.end(), function_sorter);
     }
 
 

--- a/generator/prigenerator.cpp
+++ b/generator/prigenerator.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "prigenerator.h"
 #include "shellgenerator.h"
 #include "reporthandler.h"
@@ -81,8 +83,12 @@ static QString combineIncludes(const QString& text) {
       result += line + "\n";
     }
   }
-  QStringList includeList = includes.toList();
-  qSort(includeList);
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+      QStringList includeList = includes.toList();
+#else
+      QStringList includeList(includes.begin(), includes.end());
+#endif
+  std::sort(includeList.begin(), includeList.end());
   result = includeList.join("\n") + result;
   return result;
 }
@@ -129,7 +135,7 @@ void PriGenerator::generate()
         int idx = folder.indexOf('/');
         folder = folder.left(idx);
 
-        qSort(list.begin(), list.end());
+        std::sort(list.begin(), list.end());
         FileOut file(m_out_dir + "/generated_cpp/" + pri.key());
       
         // strange idea to do the file compacting so late, but it is the most effective way without patching the generator a lot
@@ -146,7 +152,7 @@ void PriGenerator::generate()
         file.stream << "\n";
         file.stream << "SOURCES += \\\n";
         list = pri.value().sources;
-        qSort(list.begin(), list.end());
+        std::sort(list.begin(), list.end());
         if (compact) {
           list = compactFiles(list, ".cpp", m_out_dir + "/generated_cpp/" + folder, folder); 
         }

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "setupgenerator.h"
 #include "shellgenerator.h"
 #include "reporthandler.h"
@@ -65,7 +67,13 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
     }
   }
   QSet<QString> r;
-  for (QString op :  operatorCodes.toList()) {
+  for (QString op :
+#       if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+              operatorCodes.toList()
+#       else
+              QStringList(operatorCodes.begin(), operatorCodes.end())
+#       endif
+      ) {
     if (op == ">" || op == "<" || op == ">=" || op == "<=" || op == "==" || op == "!=") {
       r.insert("PythonQt::Type_RichCompare");
     } else if (op == "+") {
@@ -122,8 +130,12 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
   }
 
 
-  QStringList result = r.toList();
-  qSort(result);
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+      QStringList result = r.toList();
+#else
+      QStringList result(r.begin(), r.end());
+#endif
+  std::sort(result.begin(), result.end());
   return result;
 }
 
@@ -223,7 +235,7 @@ void SetupGenerator::generate()
       }
     }
   }
-  qSort(classes_with_polymorphic_id.begin(), classes_with_polymorphic_id.end(), class_less_than);
+  std::sort(classes_with_polymorphic_id.begin(), classes_with_polymorphic_id.end(), class_less_than);
 
   QHashIterator<QString, QList<const AbstractMetaClass*> > pack(packHash);
   while (pack.hasNext()) {
@@ -231,7 +243,7 @@ void SetupGenerator::generate()
     QList<const AbstractMetaClass*> list = pack.value();
     if (list.isEmpty())
       continue;
-    qSort(list.begin(), list.end(), class_less_than);
+    std::sort(list.begin(), list.end(), class_less_than);
 
     QString packKey = pack.key();
     QString packName = pack.key();
@@ -374,7 +386,11 @@ void SetupGenerator::generate()
       }
       s << endl;
 
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
       QStringList list = listRegistration.toList();
+#else
+      QStringList list(listRegistration.begin(), listRegistration.end());
+#endif
       list.sort();
       Q_FOREACH(QString name, list) {
         if (name.contains("Ssl")) {

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "shellgenerator.h"
 #include "reporthandler.h"
 
@@ -322,7 +324,11 @@ AbstractMetaFunctionList ShellGenerator::getFunctionsToWrap(const AbstractMetaCl
     AbstractMetaClass::VirtualFunctions | AbstractMetaClass::WasVisible
     | AbstractMetaClass::NotRemovedFromTargetLang | AbstractMetaClass::ClassImplements
     );
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
   QSet<AbstractMetaFunction*> set1 = QSet<AbstractMetaFunction*>::fromList(functions);
+#else
+  QSet<AbstractMetaFunction*> set1(functions.begin(), functions.end());
+#endif
   for (AbstractMetaFunction* func :  functions2) {
     set1.insert(func);
   }
@@ -331,14 +337,20 @@ AbstractMetaFunctionList ShellGenerator::getFunctionsToWrap(const AbstractMetaCl
 
   bool hasPromoter = meta_class->typeEntry()->shouldCreatePromoter();
 
-  for (AbstractMetaFunction* func :  set1.toList()) {
+  for (AbstractMetaFunction* func :
+#   if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+          set1.toList()
+#   else
+          QList<AbstractMetaFunction*>(set1.begin(), set1.end())
+#   endif
+      ) {
     if (func->implementingClass()==meta_class) {
       if (hasPromoter || func->wasPublic()) {
         resultFunctions << func;
       }
     }
   }
-  qSort(resultFunctions.begin(), resultFunctions.end(), function_sorter);
+  std::sort(resultFunctions.begin(), resultFunctions.end(), function_sorter);
   return resultFunctions;
 }
 
@@ -348,7 +360,7 @@ AbstractMetaFunctionList ShellGenerator::getVirtualFunctionsForShell(const Abstr
     AbstractMetaClass::VirtualFunctions | AbstractMetaClass::WasVisible
         | AbstractMetaClass::NotRemovedFromTargetLang
     );
-  qSort(functions.begin(), functions.end(), function_sorter);
+  std::sort(functions.begin(), functions.end(), function_sorter);
   return functions;
 }
 
@@ -361,7 +373,7 @@ AbstractMetaFunctionList ShellGenerator::getProtectedFunctionsThatNeedPromotion(
       functions << func;
     }
   }
-  qSort(functions.begin(), functions.end(), function_sorter);
+  std::sort(functions.begin(), functions.end(), function_sorter);
   return functions;
 }
 

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "shellheadergenerator.h"
 
 #include <QtCore/QDir>
@@ -115,7 +117,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
   s << "#include <PythonQt.h>" << endl << endl;
 
   IncludeList list = meta_class->typeEntry()->extraIncludes();
-  qSort(list.begin(), list.end());
+  std::sort(list.begin(), list.end());
   for (const Include & inc :  list) {
     ShellGenerator::writeInclude(s, inc);
   }
@@ -185,7 +187,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       << " : public " << meta_class->qualifiedCppName() << endl << "{ public:" << endl;
 
     AbstractMetaEnumList enums1 = meta_class->enums();
-    qSort(enums1.begin(), enums1.end(), enum_lessThan);
+    std::sort(enums1.begin(), enums1.end(), enum_lessThan);
     for (AbstractMetaEnum * enum1 :  enums1) {
       if (enum1->wasProtected()) {
         s << "enum " << enum1->name() << "{" << endl;
@@ -263,7 +265,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
   s << "public:" << endl;
 
   AbstractMetaEnumList enums1 = meta_class->enums();
-  qSort(enums1.begin(), enums1.end(), enum_lessThan);
+  std::sort(enums1.begin(), enums1.end(), enum_lessThan);
   AbstractMetaEnumList enums;
   QList<FlagsTypeEntry*> flags;
   for (AbstractMetaEnum * enum1 :  enums1) {
@@ -409,7 +411,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
   }
 
   AbstractMetaFieldList fields = meta_class->fields();
-  qSort(fields.begin(), fields.end(), field_lessThan);
+  std::sort(fields.begin(), fields.end(), field_lessThan);
 
   // TODO: move "So" check to typesystem, e.g. allow star in rejection...
   // Field accessors

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <algorithm> // for std::sort
+
 #include "shellimplgenerator.h"
 #include "reporthandler.h"
 #include "fileout.h"
@@ -82,7 +84,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   //    return;
 
   IncludeList list = meta_class->typeEntry()->extraIncludes();
-  qSort(list.begin(), list.end());
+  std::sort(list.begin(), list.end());
   foreach (const Include &inc, list) {
     ShellGenerator::writeInclude(s, inc);
   }  


### PR DESCRIPTION
This completes the qSort handling in generator/ including related changes caused by the removal of QSet<>::toList() and QSet<>::fromList() in Qt6 (obsoleted in Qt5.14).