### PR TITLE
Qt6: QString::SkipEmptyParts moved to Qt

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -110,7 +110,7 @@ int main(int argc, char *argv[])
         FileOut::license = true;
 
     if (args.contains("rebuild-only")) {
-        QStringList classes = args.value("rebuild-only").split(",", QString::SkipEmptyParts);
+        QStringList classes = args.value("rebuild-only").split(",", Qt::SkipEmptyParts);
         TypeDatabase::instance()->setRebuildClasses(classes);
     }
 

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -121,7 +121,7 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
     CodeSnipList code_snips = cls->typeEntry()->codeSnips();
     for (const CodeSnip &cs :  code_snips) {
       if (cs.language == TypeSystem::PyWrapperOperators) {
-        QStringList values = cs.code().split(" ", QString::SkipEmptyParts);
+        QStringList values = cs.code().split(" ", Qt::SkipEmptyParts);
         for (QString value :  values) {
           r.insert(value);
         }

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -48,6 +48,16 @@
 #include <QtCore/QMap>
 #include <QDebug>
 
+/* QString::SkipEmptyParts was replicated in Qt::SplitBehavior in 15.4 and the
+ * QString original deprecated then it was removed in Qt6.  This provides
+ * forward compatibility with Qt6 for versions of Qt prior to 15.4:
+ */
+#if QT_VERSION < QT_VERSION_CHECK(5,14,0)
+    namespace Qt {
+        const QString::SplitBehavior SkipEmptyParts = QString::SkipEmptyParts;
+    };
+#endif
+
 class Indentor;
 
 class AbstractMetaType;
@@ -1159,7 +1169,8 @@ public:
         foreach (const QString &_warning, m_suppressedWarnings) {
             QString warning(QString(_warning).replace("\\*", "&place_holder_for_asterisk;"));
 
-            QStringList segs = warning.split("*", QString::SkipEmptyParts);
+            QStringList segs = warning.split("*", Qt::SkipEmptyParts);
+
             if (segs.size() == 0)
                 continue ;
 


### PR DESCRIPTION
The new declaration is in 5.14 and the old is removed in 6, the patch provides forward compatibility with older versions of Qt.