### PR TITLE
Qt6: QTextStream compatibility

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -56,7 +56,9 @@
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
 #include <QtCore/QFileInfo>
-#include <QtCore/QTextCodec>
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#   include <QtCore/QTextCodec>
+#endif
 #include <QtCore/QTextStream>
 #include <QtCore/QVariant>
 
@@ -402,7 +404,10 @@ bool AbstractMetaBuilder::build()
         return false;
 
     QTextStream stream(&file);
-    stream.setCodec(QTextCodec::codecForName("UTF-8"));
+#   if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+        stream.setCodec(QTextCodec::codecForName("UTF-8"));
+        /* Note required in Qt6: see the same call in asttoxml.cpp */
+#   endif
     QByteArray contents = stream.readAll().toUtf8();
     file.close();
 

--- a/generator/asttoxml.cpp
+++ b/generator/asttoxml.cpp
@@ -47,7 +47,9 @@
 
 #include <QXmlStreamWriter>
 #include <QTextStream>
-#include <QTextCodec>
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
+#   include <QTextCodec>
+#endif
 #include <QFile>
 
 void astToXML(QString name) {
@@ -57,7 +59,18 @@ void astToXML(QString name) {
         return;
 
     QTextStream stream(&file);
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     stream.setCodec(QTextCodec::codecForName("UTF-8"));
+#else
+    /* NOTE, for Qt6:
+     *
+     *  stream.setEncoding(QStringConverter::Utf8)
+     *
+     * is the default but will be overridden if the UTF-16 BOM is seen.  This
+     * is almost certainly the correct behavior because the BOM isn't valid in
+     * a text stream otherwise.
+     */
+#endif
     QByteArray contents = stream.readAll().toUtf8();
     file.close();
 
@@ -164,7 +177,7 @@ void writeOutClass(QXmlStreamWriter &s, ClassModelItem &item) {
         writeOutEnum(s, enumItem);
     }
 
-    QHash<QString, FunctionModelItem> functionMap = item->functionMap();
+    QMultiHash<QString, FunctionModelItem> functionMap = item->functionMap();
     for (FunctionModelItem funcItem : functionMap.values()) {
         writeOutFunction(s, funcItem);
     }

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -48,6 +48,9 @@
 #include <QtCore/QMap>
 #include <QDebug>
 
+/* BEGIN: Qt6 compatibility.  The following can removed when versions of Qt
+ * prior to 5.14 are no longer supported.
+ */
 /* QString::SkipEmptyParts was replicated in Qt::SplitBehavior in 15.4 and the
  * QString original deprecated then it was removed in Qt6.  This provides
  * forward compatibility with Qt6 for versions of Qt prior to 15.4:
@@ -57,6 +60,27 @@
         const QString::SplitBehavior SkipEmptyParts = QString::SkipEmptyParts;
     };
 #endif
+
+/* Global endl (::endl) is used extensively in the generator .cpp files.  This
+ * was supported by Qt until Qt6.  In Qt5.14 Qt::endl was added in anticipation
+ * of the Qt6 change and the use of global endl could be avoided (it does not
+ * seem to have been explicitly deprecated).  This gives backward compatibility
+ * for global endl in Qt6 (not Qt5, where global endl was still available).
+ *
+ * Note that 'constexpr' is available in Qt6 because Qt6 requires C++17;
+ * consexpr was introduced in C++11.  Likewise for decltype.  Qt::endl is a
+ * function so ::endl is a pointer to the function and the implicit conversion
+ * is used; this is to cause an compiler error in the future if the base type
+ * of Qt::endl changes.
+ *
+ * When versions of Qt older than 5.14 are no longer supported this can be
+ * removed however all the 'endl' references in the code will need to be
+ * changed to Qt::endl.
+ */
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+    static const constexpr decltype (Qt::endl) *endl = Qt::endl;
+#endif
+/* END: Qt compatibility. */
 
 class Indentor;
 

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -68,7 +68,7 @@
  * for global endl in Qt6 (not Qt5, where global endl was still available).
  *
  * Note that 'constexpr' is available in Qt6 because Qt6 requires C++17;
- * consexpr was introduced in C++11.  Likewise for decltype.  Qt::endl is a
+ * constexpr was introduced in C++11.  Likewise for decltype.  Qt::endl is a
  * function so ::endl is a pointer to the function and the implicit conversion
  * is used; this is to cause an compiler error in the future if the base type
  * of Qt::endl changes.


### PR DESCRIPTION
This provides compatibility with the removal of the global ::endl for use with QTextStream; Qt6 requires Qt::endl.

It also includes Qt6 specific changes necessary to deal with the replacement of QTextCodec by QStringConverter and the slight changes to the default setup of QTextStream (to UTF-8 with auto-detect of UTF-16).