### PR TITLE
Eliminate warnings about anonymous structs on GCC

### DIFF
--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -683,63 +683,63 @@ void _FunctionModelItem::setException(const QString &exception)
 
 bool _FunctionModelItem::isVariadics() const
 {
-  return _M_isVariadics;
+  return _M.isVariadics;
 }
 
 void _FunctionModelItem::setVariadics(bool isVariadics)
 {
-  _M_isVariadics = isVariadics;
+  _M.isVariadics = isVariadics;
 }
 
 bool _FunctionModelItem::isVirtual() const
 {
-  return _M_isVirtual;
+  return _M.isVirtual;
 }
 
 void _FunctionModelItem::setVirtual(bool isVirtual)
 {
-  _M_isVirtual = isVirtual;
+  _M.isVirtual = isVirtual;
 }
 
 bool _FunctionModelItem::isInline() const
 {
-  return _M_isInline;
+  return _M.isInline;
 }
 
 void _FunctionModelItem::setInline(bool isInline)
 {
-  _M_isInline = isInline;
+  _M.isInline = isInline;
 }
 
 bool _FunctionModelItem::isExplicit() const
 {
-  return _M_isExplicit;
+  return _M.isExplicit;
 }
 
 void _FunctionModelItem::setExplicit(bool isExplicit)
 {
-  _M_isExplicit = isExplicit;
+  _M.isExplicit = isExplicit;
 }
 
 bool _FunctionModelItem::isAbstract() const
 {
-  return _M_isAbstract;
+  return _M.isAbstract;
 }
 
 void _FunctionModelItem::setAbstract(bool isAbstract)
 {
-  _M_isAbstract = isAbstract;
+  _M.isAbstract = isAbstract;
 }
 
 // Qt
 bool _FunctionModelItem::isInvokable() const
 {
-    return _M_isInvokable;
+    return _M.isInvokable;
 }
 
 void _FunctionModelItem::setInvokable(bool isInvokable)
 {
-    _M_isInvokable = isInvokable;
+    _M.isInvokable = isInvokable;
 }
 
 // ---------------------------------------------------------------------------
@@ -907,92 +907,92 @@ void _MemberModelItem::setAccessPolicy(CodeModel::AccessPolicy accessPolicy)
 
 bool _MemberModelItem::isStatic() const
 {
-  return _M_isStatic;
+  return _M.isStatic;
 }
 
 void _MemberModelItem::setStatic(bool isStatic)
 {
-  _M_isStatic = isStatic;
+  _M.isStatic = isStatic;
 }
 
 bool _MemberModelItem::isConstant() const
 {
-  return _M_isConstant;
+  return _M.isConstant;
 }
 
 void _MemberModelItem::setConstant(bool isConstant)
 {
-  _M_isConstant = isConstant;
+  _M.isConstant = isConstant;
 }
 
 bool _MemberModelItem::isConstexpr() const
 {
-  return _M_isConstexpr;
+  return _M.isConstexpr;
 }
 
 void _MemberModelItem::setConstexpr(bool isConstexpr)
 {
-  _M_isConstexpr = isConstexpr;
+  _M.isConstexpr = isConstexpr;
 }
 
 bool _MemberModelItem::isVolatile() const
 {
-  return _M_isVolatile;
+  return _M.isVolatile;
 }
 
 void _MemberModelItem::setVolatile(bool isVolatile)
 {
-  _M_isVolatile = isVolatile;
+  _M.isVolatile = isVolatile;
 }
 
 bool _MemberModelItem::isAuto() const
 {
-  return _M_isAuto;
+  return _M.isAuto;
 }
 
 void _MemberModelItem::setAuto(bool isAuto)
 {
-  _M_isAuto = isAuto;
+  _M.isAuto = isAuto;
 }
 
 bool _MemberModelItem::isFriend() const
 {
-  return _M_isFriend;
+  return _M.isFriend;
 }
 
 void _MemberModelItem::setFriend(bool isFriend)
 {
-  _M_isFriend = isFriend;
+  _M.isFriend = isFriend;
 }
 
 bool _MemberModelItem::isRegister() const
 {
-  return _M_isRegister;
+  return _M.isRegister;
 }
 
 void _MemberModelItem::setRegister(bool isRegister)
 {
-  _M_isRegister = isRegister;
+  _M.isRegister = isRegister;
 }
 
 bool _MemberModelItem::isExtern() const
 {
-  return _M_isExtern;
+  return _M.isExtern;
 }
 
 void _MemberModelItem::setExtern(bool isExtern)
 {
-  _M_isExtern = isExtern;
+  _M.isExtern = isExtern;
 }
 
 bool _MemberModelItem::isMutable() const
 {
-  return _M_isMutable;
+  return _M.isMutable;
 }
 
 void _MemberModelItem::setMutable(bool isMutable)
 {
-  _M_isMutable = isMutable;
+  _M.isMutable = isMutable;
 }
 
 // kate: space-indent on; indent-width 2; replace-tabs on;

--- a/generator/parser/codemodel.h
+++ b/generator/parser/codemodel.h
@@ -517,16 +517,16 @@ private:
   {
     struct
     {
-      uint _M_isConstant: 1;
-      uint _M_isConstexpr: 1;
-      uint _M_isVolatile: 1;
-      uint _M_isStatic: 1;
-      uint _M_isAuto: 1;
-      uint _M_isFriend: 1;
-      uint _M_isRegister: 1;
-      uint _M_isExtern: 1;
-      uint _M_isMutable: 1;
-    };
+      uint isConstant: 1;
+      uint isConstexpr: 1;
+      uint isVolatile: 1;
+      uint isStatic: 1;
+      uint isAuto: 1;
+      uint isFriend: 1;
+      uint isRegister: 1;
+      uint isExtern: 1;
+      uint isMutable: 1;
+    } _M;
     uint _M_flags;
   };
 
@@ -586,13 +586,13 @@ private:
   {
     struct
     {
-      uint _M_isVirtual: 1;
-      uint _M_isInline: 1;
-      uint _M_isAbstract: 1;
-      uint _M_isExplicit: 1;
-      uint _M_isVariadics: 1;
-      uint _M_isInvokable : 1; // Qt
-    };
+      uint isVirtual: 1;
+      uint isInline: 1;
+      uint isAbstract: 1;
+      uint isExplicit: 1;
+      uint isVariadics: 1;
+      uint isInvokable : 1; // Qt
+    } _M;
     uint _M_flags;
   };
 

--- a/generator/parser/rpp/pp-engine-bits.h
+++ b/generator/parser/rpp/pp-engine-bits.h
@@ -577,7 +577,7 @@ InputIterator pp::handle_define (InputIterator _first, InputIterator _last)
 
   if (_first != _last && *_first == '(')
     {
-      macro.function_like = true;
+      macro.is.function_like = true;
       macro.formals.reserve (5);
 
       _first = skip_blanks (++_first, _last); // skip '('
@@ -589,7 +589,7 @@ InputIterator pp::handle_define (InputIterator _first, InputIterator _last)
 
       if (*_first == '.')
         {
-          macro.variadics = true;
+          macro.is.variadics = true;
           while (*_first == '.')
             ++_first;
         }
@@ -606,7 +606,7 @@ InputIterator pp::handle_define (InputIterator _first, InputIterator _last)
 
           if (*_first == '.')
             {
-              macro.variadics = true;
+              macro.is.variadics = true;
               while (*_first == '.')
                 ++_first;
             }

--- a/generator/parser/rpp/pp-environment.h
+++ b/generator/parser/rpp/pp-environment.h
@@ -89,7 +89,7 @@ public:
   inline void unbind (pp_fast_string const *_name)
   {
     if (pp_macro *m = resolve (_name))
-      m->hidden = true;
+      m->is.hidden = true;
   }
 
   inline void unbind (char const *_s, std::size_t _size)
@@ -103,7 +103,7 @@ public:
     std::size_t h = hash_code (*_name) % _M_hash_size;
     pp_macro *it = _M_base [h];
 
-    while (it && it->name && it->hash_code == h && (*it->name != *_name || it->hidden))
+    while (it && it->name && it->hash_code == h && (*it->name != *_name || it->is.hidden))
       it = it->next;
 
     return it;

--- a/generator/parser/rpp/pp-macro-expander.h
+++ b/generator/parser/rpp/pp-macro-expander.h
@@ -250,7 +250,7 @@ public:
             static bool hide_next = false; // ### remove me
 
             pp_macro *macro = env.resolve (name_buffer, name_size);
-            if (! macro || macro->hidden || hide_next)
+            if (! macro || macro->is.hidden || hide_next)
               {
                 hide_next = ! strcmp (name_buffer, "defined");
 
@@ -278,13 +278,13 @@ public:
                 continue;
               }
 
-            if (! macro->function_like)
+            if (! macro->is.function_like)
               {
                 pp_macro *m = 0;
 
                 if (macro->definition)
                   {
-                    macro->hidden = true;
+                    macro->is.hidden = true;
 
                     std::string tmp;
                     tmp.reserve (256);
@@ -316,7 +316,7 @@ public:
                           std::copy (tmp.begin (), tmp.end (), _result);
                       }
 
-                    macro->hidden = false;
+                    macro->is.hidden = false;
                   }
 
                 if (! m)
@@ -370,15 +370,15 @@ public:
               _first = arg_it;
 
 #if 0 // ### enable me
-              assert ((macro->variadics && macro->formals.size () >= actuals.size ())
+              assert ((macro->is.variadics && macro->formals.size () >= actuals.size ())
                           || macro->formals.size() == actuals.size());
 #endif
 
               pp_frame frame (macro, &actuals);
               pp_macro_expander expand_macro (env, &frame);
-              macro->hidden = true;
+              macro->is.hidden = true;
               expand_macro (macro->definition->begin (), macro->definition->end (), _result);
-              macro->hidden = false;
+              macro->is.hidden = false;
               generated_lines += expand_macro.lines;
           }
         else
@@ -394,7 +394,7 @@ public:
   {
     InputIterator arg_end = skip_argument (_first, _last);
 
-    while (_macro->variadics && _first != arg_end && arg_end != _last && *arg_end == ','
+    while (_macro->is.variadics && _first != arg_end && arg_end != _last && *arg_end == ','
         && (_actuals.size () + 1) == _macro->formals.size ())
       {
         arg_end = skip_argument (++arg_end, _last);

--- a/generator/parser/rpp/pp-macro.h
+++ b/generator/parser/rpp/pp-macro.h
@@ -62,7 +62,7 @@ struct pp_macro
       int unsigned hidden: 1;
       int unsigned function_like: 1;
       int unsigned variadics: 1;
-    };
+    } is;
   };
 
   int lines;

--- a/generator/parser/rpp/preprocessor.cpp
+++ b/generator/parser/rpp/preprocessor.cpp
@@ -143,7 +143,7 @@ QList<Preprocessor::MacroItem> Preprocessor::macros() const
             item.parameters += QString::fromLatin1(m->formals[i]->begin(),
                     m->formals[i]->size());
         }
-        item.isFunctionLike = m->function_like;
+        item.isFunctionLike = m->is.function_like;
 
 #ifdef PP_WITH_MACRO_POSITION
         item.fileName = QString::fromLatin1(m->file->begin(), m->file->size());


### PR DESCRIPTION
Corresponding warnings are already turned off on clang in generator/generator.pri.  There's no G++ command-line option to turn them off without explicitly disabling other warnings (-Wpedantic).