### PR TITLE
Eliminate warnings about #warning

### DIFF
--- a/generator/parser/declarator_compiler.cpp
+++ b/generator/parser/declarator_compiler.cpp
@@ -135,7 +135,7 @@ void DeclaratorCompiler::visitPtrOperator(PtrOperatorAST *node)
   if (node->mem_ptr)
     {
 #if defined(__GNUC__)
-#warning "ptr to mem -- not implemented"
+#pragma GCC warning "ptr to mem -- not implemented"
 #endif
     }
 }

--- a/generator/parser/name_compiler.cpp
+++ b/generator/parser/name_compiler.cpp
@@ -80,7 +80,7 @@ void NameCompiler::visitUnqualifiedName(UnqualifiedNameAST *node)
   if (OperatorFunctionIdAST *op_id = node->operator_id)
     {
 #if defined(__GNUC__)
-#warning "NameCompiler::visitUnqualifiedName() -- implement me"
+#pragma GCC warning "NameCompiler::visitUnqualifiedName() -- implement me"
 #endif
 
       if (op_id->op && op_id->op->op)
@@ -93,7 +93,7 @@ void NameCompiler::visitUnqualifiedName(UnqualifiedNameAST *node)
       else if (op_id->type_specifier)
         {
 #if defined(__GNUC__)
-#warning "don't use an hardcoded string as cast' name"
+#pragma GCC warning "don't use an hardcoded string as cast' name"
 #endif
           Token const &tk = _M_token_stream->token ((int) op_id->start_token);
           Token const &end_tk = _M_token_stream->token ((int) op_id->end_token);

--- a/generator/parser/parser.cpp
+++ b/generator/parser/parser.cpp
@@ -799,7 +799,7 @@ bool Parser::parseAsmDefinition(DeclarationAST *&node)
   parseCvQualify(cv);
 
 #if defined(__GNUC__)
-#warning "implement me"
+#pragma GCC warning "implement me"
 #endif
   skip('(', ')');
   token_stream.nextToken();
@@ -2358,7 +2358,7 @@ bool Parser::parseInitializerClause(InitializerClauseAST *&node)
   if (token_stream.lookAhead() == '{')
     {
 #if defined(__GNUC__)
-#warning "implement me"
+#pragma GCC warning "implement me"
 #endif
       if (skip('{','}'))
         token_stream.nextToken();
@@ -2382,7 +2382,7 @@ bool Parser::parseInitializerClause(InitializerClauseAST *&node)
 bool Parser::parsePtrToMember(PtrToMemberAST *&node)
 {
 #if defined(__GNUC__)
-#warning "implemente me (AST)"
+#pragma GCC warning "implemente me (AST)"
 #endif
 
   std::size_t start = token_stream.cursor();
@@ -2556,7 +2556,7 @@ bool Parser::parseStatement(StatementAST *&node)
     case Token_break:
     case Token_continue:
 #if defined(__GNUC__)
-#warning "implement me"
+#pragma GCC warning "implement me"
 #endif
       token_stream.nextToken();
       ADVANCE(';', ";");
@@ -2564,7 +2564,7 @@ bool Parser::parseStatement(StatementAST *&node)
 
     case Token_goto:
 #if defined(__GNUC__)
-#warning "implement me"
+#pragma GCC warning "implement me"
 #endif
       token_stream.nextToken();
       ADVANCE(Token_identifier, "identifier");
@@ -3207,7 +3207,7 @@ bool Parser::parseDeclarationInternal(DeclarationAST *&node)
       ADVANCE(';', ";");
 
 #if defined(__GNUC__)
-#warning "mark the ast as constant"
+#pragma GCC warning "mark the ast as constant"
 #endif
       SimpleDeclarationAST *ast = CreateNode<SimpleDeclarationAST>(_M_pool);
       ast->init_declarators = declarators;
@@ -3308,7 +3308,7 @@ bool Parser::parseDeclarationInternal(DeclarationAST *&node)
 bool Parser::skipFunctionBody(StatementAST *&)
 {
 #if defined(__GNUC__)
-#warning "Parser::skipFunctionBody() -- implement me"
+#pragma GCC warning "Parser::skipFunctionBody() -- implement me"
 #endif
   Q_ASSERT(0); // ### not implemented
   return 0;
@@ -3337,7 +3337,7 @@ bool Parser::parseTypeSpecifierOrClassSpec(TypeSpecifierAST *&node)
 bool Parser::parseTryBlockStatement(StatementAST *&node)
 {
 #if defined(__GNUC__)
-#warning "implement me"
+#pragma GCC warning "implement me"
 #endif
   CHECK(Token_try);
 


### PR DESCRIPTION
The warnings are already only emitted with GCC so changing them to the GCC diagnostic pragma is safe.