### PR TITLE
Qt6: generator/typesystem.cpp: XML workround

### DIFF
--- a/generator/generator.pri
+++ b/generator/generator.pri
@@ -70,6 +70,11 @@ SOURCES += \
    
 QT += core xml
 
+greaterThan(QT_MAJOR_VERSION, 5) {
+    QT += core5compat
+    message("WARNING: Qt module core5compat for XML handling in typesystem.cpp")
+}
+
 win32-msvc.net {
         QMAKE_CXXFLAGS += /Zm500
         QMAKE_CXXFLAGS -= -Zm200

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -51,6 +51,22 @@
 #include <QtXml>
 #include <qcompilerdetection.h> // Q_FALLTHROUGH
 
+/* This file needs to be rewritten as documented here:
+ *
+ * See: https://doc.qt.io/qt-6/xml-changes-qt6.html
+ *
+ * The rewrite may be backward compatible to Qt4.3 APIs because the base
+ * facilites (QXmlStreamReader) used to relace the 'SAX' parser were apparently
+ * available then.  Use of Xml5Compat is a work round until such a rewrite has
+ * been done.
+ */
+#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
+#   if defined(__GNUC__)
+#       pragma GCC warning "Qt6: implement Qt6 compatible XML reading"
+#   endif
+#   include <QtCore5Compat/QXmlDefaultHandler>
+#endif
+
 QString strings_Object = QLatin1String("Object");
 QString strings_String = QLatin1String("String");
 QString strings_Thread = QLatin1String("Thread");


### PR DESCRIPTION
This works around the need to rewrite the XML parser in generator/typesystem.cpp by invoking the Qt5 compatibility library; this is the only thing in the generator which requires it but the alternative is a complete rewrite of the XML reading code.