### PR TITLE
pythonqt_generator modified argument handling, make generate

### DIFF
--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -152,7 +152,7 @@ AbstractMetaFunction::~AbstractMetaFunction()
 bool AbstractMetaFunction::isModifiedRemoved(int types) const
 {
     FunctionModificationList mods = modifications(implementingClass());
-    foreach (FunctionModification mod, mods) {
+    for (FunctionModification mod : mods) {
         if (!mod.isRemoveModifier())
             continue;
 
@@ -172,7 +172,7 @@ bool AbstractMetaFunction::needsCallThrough() const
     if (argumentsHaveNativeId() || !isStatic())
         return true;
 
-    foreach (const AbstractMetaArgument *arg, arguments()) {
+    for (const AbstractMetaArgument *arg : arguments()) {
         if (arg->type()->isArray() || arg->type()->isTargetLangEnum() || arg->type()->isTargetLangFlags())
             return true;
     }
@@ -193,7 +193,7 @@ bool AbstractMetaFunction::needsSuppressUncheckedWarning() const
 {
     for (int i=-1; i<=arguments().size(); ++i) {
         QList<ReferenceCount> referenceCounts = this->referenceCounts(implementingClass(), i);
-        foreach (ReferenceCount referenceCount, referenceCounts) {
+        for (ReferenceCount referenceCount : referenceCounts) {
             if (referenceCount.action != ReferenceCount::Set)
                 return true;
         }
@@ -205,7 +205,7 @@ QString AbstractMetaFunction::marshalledName() const
 {
     QString returned = "__qt_" + name();
     AbstractMetaArgumentList arguments = this->arguments();
-    foreach (const AbstractMetaArgument *arg, arguments) {
+    for (const AbstractMetaArgument *arg : arguments) {
         returned += "_";
         if (arg->type()->isNativePointer()) {
             returned += "nativepointer";
@@ -318,7 +318,7 @@ AbstractMetaFunction *AbstractMetaFunction::copy() const
     cpy->setException(exception());
     cpy->setOriginalAttributes(originalAttributes());
 
-    foreach (AbstractMetaArgument *arg, arguments())
+    for (AbstractMetaArgument *arg : arguments())
         cpy->addArgument(arg->copy());
 
     Q_ASSERT((!type() && !cpy->type())
@@ -389,9 +389,9 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
     QList<ReferenceCount> returned;
 
     FunctionModificationList mods = this->modifications(cls);
-    foreach (FunctionModification mod, mods) {
+    for (FunctionModification mod : mods) {
         QList<ArgumentModification> argument_mods = mod.argument_mods;
-        foreach (ArgumentModification argument_mod, argument_mods) {
+        for (ArgumentModification argument_mod : argument_mods) {
             if (argument_mod.index != idx && idx != -2)
                 continue;
             returned += argument_mod.referenceCounts;
@@ -404,9 +404,9 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
 QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.replaced_default_expression.isEmpty()) {
                 return argument_modification.replaced_default_expression;
@@ -420,9 +420,9 @@ QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass 
 bool AbstractMetaFunction::removedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && argument_modification.removed_default_expression) {
                 return true;
@@ -437,9 +437,9 @@ bool AbstractMetaFunction::resetObjectAfterUse(int argument_idx) const
 {
     const AbstractMetaClass *cls = declaringClass();
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argumentModifications = modification.argument_mods;
-        foreach (ArgumentModification argumentModification, argumentModifications) {
+        for (ArgumentModification argumentModification : argumentModifications) {
             if (argumentModification.index == argument_idx && argumentModification.reset_after_use)
                 return true;            
         }
@@ -458,9 +458,9 @@ QString AbstractMetaFunction::nullPointerDefaultValue(const AbstractMetaClass *m
 
     do {
         FunctionModificationList modifications = this->modifications(cls);
-        foreach (FunctionModification modification, modifications) {
+        for (FunctionModification modification : modifications) {
             QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            foreach (ArgumentModification argument_modification, argument_modifications) {
+            for (ArgumentModification argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return argument_modification.null_pointer_default_value;
@@ -483,9 +483,9 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
 
     do {
         FunctionModificationList modifications = this->modifications(cls);
-        foreach (FunctionModification modification, modifications) {
+        for (FunctionModification modification : modifications) {
             QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            foreach (ArgumentModification argument_modification, argument_modifications) {
+            for (ArgumentModification argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return true;
@@ -502,13 +502,13 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
 QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
-            foreach (CodeSnip snip, argument_modification.conversion_rules) {
+            for (CodeSnip snip : argument_modification.conversion_rules) {
                 if (snip.language == language && !snip.code().isEmpty())
                     return snip.code();
             }
@@ -521,9 +521,9 @@ QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int 
 QString AbstractMetaFunction::argumentReplaced(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key && !argument_modification.replace_value.isEmpty()) {
                 return argument_modification.replace_value;
             }
@@ -536,9 +536,9 @@ QString AbstractMetaFunction::argumentReplaced(int key) const
 bool AbstractMetaFunction::argumentRemoved(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key) {
                 if (argument_modification.removed) {
                     return true;
@@ -553,7 +553,7 @@ bool AbstractMetaFunction::argumentRemoved(int key) const
 bool AbstractMetaFunction::isVirtualSlot() const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if (modification.isVirtualSlot())
             return true;
     }
@@ -564,13 +564,13 @@ bool AbstractMetaFunction::isVirtualSlot() const
 bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
-            foreach (TypeSystem::Ownership ownership, argument_modification.ownerships.values()) {
+            for (TypeSystem::Ownership ownership : argument_modification.ownerships.values()) {
                 if (ownership == TypeSystem::CppOwnership)
                     return true;
             }
@@ -584,7 +584,7 @@ bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cl
 bool AbstractMetaFunction::isDeprecated() const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if (modification.isDeprecated())
             return true;
     }
@@ -594,9 +594,9 @@ bool AbstractMetaFunction::isDeprecated() const
 TypeSystem::Ownership AbstractMetaFunction::ownership(const AbstractMetaClass *cls, TypeSystem::Language language, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key)
                 return argument_modification.ownerships.value(language, TypeSystem::InvalidOwnership);
         }
@@ -613,7 +613,7 @@ bool AbstractMetaFunction::isRemovedFromAllLanguages(const AbstractMetaClass *cl
 bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSystem::Language language) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if ((modification.removal & language) == language)
             return true;
     }
@@ -625,9 +625,9 @@ bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSyste
 QString AbstractMetaFunction::typeReplaced(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.modified_type.isEmpty()) {
                 return argument_modification.modified_type;
@@ -680,7 +680,7 @@ QString AbstractMetaFunction::modifiedName() const
 {
     if (m_cached_modified_name.isEmpty()) {
         FunctionModificationList mods = modifications(implementingClass());
-        foreach (FunctionModification mod, mods) {
+        for (FunctionModification mod : mods) {
             if (mod.isRenameModifier()) {
                 m_cached_modified_name = mod.renamedToName;
                 break;
@@ -752,13 +752,13 @@ AbstractMetaClass::~AbstractMetaClass()
     cls->setAttributes(attributes());
     cls->setBaseClass(baseClass());
     cls->setTypeEntry(typeEntry());
-    foreach (AbstractMetaFunction *function, functions()) {
+    for (AbstractMetaFunction *function : functions()) {
         AbstractMetaFunction *copy = function->copy();
         function->setImplementingClass(cls);
         cls->addFunction(copy);
     }
     cls->setEnums(enums());
-    foreach (const AbstractMetaField *field, fields()) {
+    for (const AbstractMetaField *field : fields()) {
         AbstractMetaField *copy = field->copy();
         copy->setEnclosingClass(cls);
         cls->addField(copy);
@@ -802,7 +802,7 @@ AbstractMetaClass *AbstractMetaClass::extractInterface()
 
         iface->setTypeEntry(typeEntry()->designatedInterface());
 
-        foreach (AbstractMetaFunction *function, functions()) {
+        for (AbstractMetaFunction *function : functions()) {
             if (!function->isConstructor())
                 iface->addFunction(function->copy());
         }
@@ -810,7 +810,7 @@ AbstractMetaClass *AbstractMetaClass::extractInterface()
 //         iface->setEnums(enums());
 //         setEnums(AbstractMetaEnumList());
 
-        foreach (const AbstractMetaField *field, fields()) {
+        for (const AbstractMetaField *field : fields()) {
             if (field->isPublic()) {
                 AbstractMetaField *new_field = field->copy();
                 new_field->setEnclosingClass(iface);
@@ -832,7 +832,7 @@ AbstractMetaFunctionList AbstractMetaClass::queryFunctionsByName(const QString &
 {
     AbstractMetaFunctionList returned;
     AbstractMetaFunctionList functions = this->functions();
-    foreach (AbstractMetaFunction *function, functions) {
+    for (AbstractMetaFunction *function : functions) {
         if (function->name() == name)
             returned.append(function);
     }
@@ -868,7 +868,7 @@ QList<ReferenceCount> AbstractMetaClass::referenceCounts() const
     QList<ReferenceCount> returned;
 
     AbstractMetaFunctionList functions = this->functions();
-    foreach (AbstractMetaFunction *function, functions) {
+    for (AbstractMetaFunction *function : functions) {
         returned += function->referenceCounts(this);
     }
 
@@ -913,7 +913,7 @@ AbstractMetaFunctionList AbstractMetaClass::virtualFunctions() const
     AbstractMetaFunctionList list = functionsInShellClass();
 
     AbstractMetaFunctionList returned;
-    foreach (AbstractMetaFunction *f, list) {
+    for (AbstractMetaFunction *f : list) {
         if (!f->isFinalInCpp() || f->isVirtualSlot())
             returned += f;
     }
@@ -925,7 +925,7 @@ AbstractMetaFunctionList AbstractMetaClass::nonVirtualShellFunctions() const
 {
     AbstractMetaFunctionList list = functionsInShellClass();
     AbstractMetaFunctionList returned;
-    foreach (AbstractMetaFunction *f, list) {
+    for (AbstractMetaFunction *f : list) {
         if (f->isFinalInCpp() && !f->isVirtualSlot())
             returned += f;
     }
@@ -987,7 +987,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
     QString currentName;
     bool hasVirtuals = false;
     AbstractMetaFunctionList final_functions;
-    foreach (AbstractMetaFunction *f, m_functions) {
+    for (AbstractMetaFunction *f : m_functions) {
         f->setOwnerClass(this);
 
         m_has_virtual_slots |= f->isVirtualSlot();
@@ -1002,7 +1002,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
                 final_functions += f;
         } else {
             if (hasVirtuals && final_functions.size() > 0) {
-                foreach (AbstractMetaFunction *final_function, final_functions) {
+                for (AbstractMetaFunction *final_function : final_functions) {
                     *final_function += AbstractMetaAttributes::ForceShellImplementation;
 
                     QString warn = QString("hiding of function '%1' in class '%2'")
@@ -1025,7 +1025,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
         FunctionModificationList mods = m_functions.at(j)->modifications(m_functions.at(j)->implementingClass());
 
         bool removed = false;
-        foreach (const FunctionModification &mod, mods) {
+        for (const FunctionModification &mod : mods) {
             if (mod.isRemoveModifier()) {
                 removed = true;
                 break ;
@@ -1040,7 +1040,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
 
             mods = m_functions.at(i)->modifications(m_functions.at(i)->implementingClass());
             bool removed = false;
-            foreach (const FunctionModification &mod, mods) {
+            for (const FunctionModification &mod : mods) {
                 if (mod.isRemoveModifier()) {
                     removed = true;
                     break ;
@@ -1066,7 +1066,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
 
 bool AbstractMetaClass::hasFieldAccessors() const
 {
-    foreach (const AbstractMetaField *field, fields()) {
+    for (const AbstractMetaField *field : fields()) {
         if (field->getter() || field->setter())
             return true;
     }
@@ -1076,7 +1076,7 @@ bool AbstractMetaClass::hasFieldAccessors() const
 
 bool AbstractMetaClass::hasDefaultToStringFunction() const
 {
-    foreach (AbstractMetaFunction *f, queryFunctionsByName("toString")) {
+    for (AbstractMetaFunction *f : queryFunctionsByName("toString")) {
         if (f->actualMinimumArgumentCount() == 0) {
             return true;
         }
@@ -1106,7 +1106,7 @@ bool AbstractMetaClass::hasSignal(const AbstractMetaFunction *other) const
     if (!other->isSignal())
         return false;
 
-    foreach (const AbstractMetaFunction *f, functions()) {
+    for (const AbstractMetaFunction *f : functions()) {
         if (f->isSignal() && f->compareTo(other) & AbstractMetaFunction::EqualName)
             return other->modifiedName() == f->modifiedName();
     }
@@ -1122,7 +1122,7 @@ QString AbstractMetaClass::name() const
 
 bool AbstractMetaClass::hasFunction(const QString &str) const
 {
-    foreach (const AbstractMetaFunction *f, functions())
+    for (const AbstractMetaFunction *f : functions())
         if (f->name() == str)
             return true;
     return false;
@@ -1134,7 +1134,7 @@ bool AbstractMetaClass::hasFunction(const QString &str) const
    they can be called from the native functions.
 */
 bool AbstractMetaClass::hasProtectedFunctions() const {
-    foreach (AbstractMetaFunction *func, m_functions) {
+    for (AbstractMetaFunction *func : m_functions) {
         if (func->isProtected())
             return true;
     }
@@ -1196,7 +1196,7 @@ bool AbstractMetaClass::hasVirtualDestructor() const
 
 static bool functions_contains(const AbstractMetaFunctionList &l, const AbstractMetaFunction *func)
 {
-    foreach (const AbstractMetaFunction *f, l) {
+    for (const AbstractMetaFunction *f : l) {
 		if ((f->compareTo(func) & AbstractMetaFunction::PrettySimilar) == AbstractMetaFunction::PrettySimilar)
             return true;
     }
@@ -1254,7 +1254,7 @@ static AbstractMetaFunction *createXetter(const AbstractMetaField *g, const QStr
     f->setOriginalAttributes(attr);
 
     FieldModificationList mods = g->modifications();
-    foreach (FieldModification mod, mods) {
+    for (FieldModification mod : mods) {
         if (mod.isRenameModifier())
             f->setName(mod.renamedTo());
         if (mod.isAccessModifier()) {
@@ -1277,7 +1277,7 @@ FieldModificationList AbstractMetaField::modifications() const
     FieldModificationList mods = enclosingClass()->typeEntry()->fieldModifications();
     FieldModificationList returned;
 
-    foreach (FieldModification mod, mods) {
+    for (FieldModification mod : mods) {
         if (mod.name == name())
             returned += mod;
     }
@@ -1350,7 +1350,7 @@ AbstractMetaFunctionList AbstractMetaClass::queryFunctions(uint query) const
 {
     AbstractMetaFunctionList functions;
 
-    foreach (AbstractMetaFunction *f, m_functions) {
+    for (AbstractMetaFunction *f : m_functions) {
 
         if ((query & VirtualSlots) && !f->isVirtualSlot())
             continue;
@@ -1499,7 +1499,7 @@ void AbstractMetaClass::addInterface(AbstractMetaClass *interface)
     if (m_extracted_interface != 0 && m_extracted_interface != interface)
         m_extracted_interface->addInterface(interface);
 
-    foreach (AbstractMetaFunction *function, interface->functions())
+    for (AbstractMetaFunction *function : interface->functions())
         if (!hasFunction(function) && !function->isConstructor()) {
             AbstractMetaFunction *cpy = function->copy();
             // We do not want this in PythonQt:
@@ -1511,7 +1511,7 @@ void AbstractMetaClass::addInterface(AbstractMetaClass *interface)
 
             // Copy the modifications in interface into the implementing classes.
             //FunctionModificationList mods = function->modifications(interface);
-            //foreach  (const FunctionModification &mod, mods) {
+            //for  (const FunctionModification &mod : mods) {
             //    m_type_entry->addFunctionModification(mod);
             //}
 
@@ -1532,7 +1532,7 @@ void AbstractMetaClass::setInterfaces(const AbstractMetaClassList &interfaces)
 
 AbstractMetaEnum *AbstractMetaClass::findEnum(const QString &enumName)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
+    for (AbstractMetaEnum *e : m_enums) {
         if (e->name() == enumName)
             return e;
     }
@@ -1552,10 +1552,10 @@ AbstractMetaEnum *AbstractMetaClass::findEnum(const QString &enumName)
 */
 AbstractMetaEnumValue *AbstractMetaClass::findEnumValue(const QString &enumValueName, AbstractMetaEnum *meta_enum)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
+    for (AbstractMetaEnum *e : m_enums) {
         if (e == meta_enum)
             continue;
-        foreach (AbstractMetaEnumValue *v, e->values()) {
+        for (AbstractMetaEnumValue *v : e->values()) {
             if (v->name() == enumValueName)
                 return v;
         }
@@ -1579,8 +1579,8 @@ AbstractMetaEnumValue *AbstractMetaClass::findEnumValue(const QString &enumValue
  */
 AbstractMetaEnum *AbstractMetaClass::findEnumForValue(const QString &enumValueName)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
-        foreach (AbstractMetaEnumValue *v, e->values()) {
+    for (AbstractMetaEnum *e : m_enums) {
+        for (AbstractMetaEnumValue *v : e->values()) {
             if (v->name() == enumValueName)
                 return e;
         }
@@ -1613,7 +1613,7 @@ static void add_extra_include_for_type(AbstractMetaClass *meta_class, const Abst
 
     if (type->hasInstantiations()) {
         QList<AbstractMetaType *> instantiations = type->instantiations();
-        foreach (AbstractMetaType *instantiation, instantiations)
+        for (AbstractMetaType *instantiation : instantiations)
             add_extra_include_for_type(meta_class, instantiation);
     }
 }
@@ -1625,7 +1625,7 @@ static void add_extra_includes_for_function(AbstractMetaClass *meta_class, const
     add_extra_include_for_type(meta_class, meta_function->type());
 
     AbstractMetaArgumentList arguments = meta_function->arguments();
-    foreach (AbstractMetaArgument *argument, arguments)
+    for (AbstractMetaArgument *argument : arguments)
         add_extra_include_for_type(meta_class, argument->type());
 }
 
@@ -1762,7 +1762,7 @@ void AbstractMetaClass::fixFunctions()
                                 bool hasNonFinalModifier = false;
                                 bool isBaseImplPrivate = false;
                                 FunctionModificationList mods = sf->modifications(sf->implementingClass());
-                                foreach (FunctionModification mod, mods) {
+                                for (FunctionModification mod : mods) {
                                     if (mod.isNonFinal()) {
                                         hasNonFinalModifier = true;
                                         break;
@@ -1818,7 +1818,7 @@ void AbstractMetaClass::fixFunctions()
                 funcs_to_add << sf;
         }
 
-        foreach (AbstractMetaFunction *f, funcs_to_add)
+        for (AbstractMetaFunction *f : funcs_to_add)
             funcs << f->copy();
 
         if (super_class) {
@@ -1833,9 +1833,9 @@ void AbstractMetaClass::fixFunctions()
 
     bool hasPrivateConstructors = false;
     bool hasPublicConstructors = false;
-    foreach (AbstractMetaFunction *func, funcs) {
+    for (AbstractMetaFunction *func : funcs) {
         FunctionModificationList mods = func->modifications(this);
-        foreach (const FunctionModification &mod, mods) {
+        for (const FunctionModification &mod : mods) {
             if (mod.isRenameModifier()) {
 //                 qDebug() << name() << func->originalName() << func << " from "
 //                          << func->implementingClass()->name() << "renamed to" << mod.renamedTo();
@@ -1872,8 +1872,8 @@ void AbstractMetaClass::fixFunctions()
     // we don't care about FinalOverload for PythonQt, so we
     // can remove this compare orgy...
     
-    /*foreach (AbstractMetaFunction *f1, funcs) {
-        foreach (AbstractMetaFunction *f2, funcs) {
+    /*for (AbstractMetaFunction *f1 : funcs) {
+        for (AbstractMetaFunction *f2 : funcs) {
             if (f1 != f2) {
                 uint cmp = f1->compareTo(f2);
                 if ((cmp & AbstractMetaFunction::EqualName)
@@ -1883,11 +1883,11 @@ void AbstractMetaClass::fixFunctions()
 //                     qDebug() << f2 << f2->implementingClass()->name() << "::" << f2->name() << f2->arguments().size() << " vs " << f1 << f1->implementingClass()->name() << "::" << f1->name() << f1->arguments().size();
 //                     qDebug() << "    " << f2;
 //                     AbstractMetaArgumentList f2Args = f2->arguments();
-//                     foreach (AbstractMetaArgument *a, f2Args)
+//                     for (AbstractMetaArgument *a : f2Args)
 //                         qDebug() << "        " << a->type()->name() << a->name();
 //                     qDebug() << "    " << f1;
 //                     AbstractMetaArgumentList f1Args = f1->arguments();
-//                     foreach (AbstractMetaArgument *a, f1Args)
+//                     for (AbstractMetaArgument *a : f1Args)
 //                         qDebug() << "        " << a->type()->name() << a->name();
 
                 }
@@ -2000,17 +2000,17 @@ AbstractMetaClass *AbstractMetaClassList::findClass(const QString &name) const
     if (name.isEmpty())
         return 0;
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass *c : *this) {
         if (c->qualifiedCppName() == name)
             return c;
     }
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass *c : *this) {
         if (c->fullName() == name)
             return c;
     }
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass *c : *this) {
         if (c->name() == name)
             return c;
     }

--- a/generator/abstractmetalang.h
+++ b/generator/abstractmetalang.h
@@ -432,7 +432,7 @@ public:
     // true if one or more of the arguments are of QtJambiObject subclasses
     bool argumentsHaveNativeId() const
     {
-        foreach (const AbstractMetaArgument *arg, m_arguments) {
+        for (const AbstractMetaArgument *arg : m_arguments) {
             if (arg->type()->hasNativeId())
                 return true;
         }

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -64,7 +64,7 @@ void Generator::generate()
 
     std::stable_sort(m_classes.begin(), m_classes.end());
 
-    foreach (AbstractMetaClass *cls, m_classes) {
+    for (AbstractMetaClass *cls : m_classes) {
         if (!shouldGenerate(cls))
             continue;
 
@@ -88,7 +88,7 @@ void Generator::printClasses()
     AbstractMetaClassList classes = m_classes;
     std::sort(classes.begin(), classes.end());
 
-    foreach (AbstractMetaClass *cls, classes) {
+    for (AbstractMetaClass *cls : classes) {
         if (!shouldGenerate(cls))
             continue;
         write(s, cls);
@@ -128,10 +128,10 @@ bool Generator::hasDefaultConstructor(const AbstractMetaType *type)
     QString full_name = type->typeEntry()->qualifiedTargetLangName();
     QString class_name = type->typeEntry()->targetLangName();
 
-    foreach (const AbstractMetaClass *java_class, m_classes) {
+    for (const AbstractMetaClass *java_class : m_classes) {
         if (java_class->typeEntry()->qualifiedTargetLangName() == full_name) {
             AbstractMetaFunctionList functions = java_class->functions();
-            foreach (const AbstractMetaFunction *function, functions) {
+            for (const AbstractMetaFunction *function : functions) {
                 if (function->arguments().size() == 0 && function->name() == class_name)
                     return true;
             }

--- a/generator/generator.pro
+++ b/generator/generator.pro
@@ -13,7 +13,7 @@ HEADERS += \
         shellimplgenerator.h \
         shellheadergenerator.h \
         setupgenerator.h
-   
+
 SOURCES += \
         generatorsetqtscript.cpp \
         metaqtscriptbuilder.cpp \
@@ -22,3 +22,9 @@ SOURCES += \
         shellimplgenerator.cpp \
         shellheadergenerator.cpp \
         setupgenerator.cpp
+
+#The generate target is NOT built automatically!
+QMAKE_EXTRA_TARGETS += generate
+
+generate.depends = $$TARGET
+generate.commands = ./$$TARGET --qt-headers="$$[QT_INSTALL_HEADERS]" --core-error --output-directory="."

--- a/generator/generatorsetqtscript.cpp
+++ b/generator/generatorsetqtscript.cpp
@@ -68,6 +68,7 @@ void GeneratorSetQtScript::buildModel(const QString pp_file) {
     ReportHandler::setContext("MetaJavaBuilder");
     builder.setFileName(pp_file);
     builder.build();
+    ReportHandler::setContext("After MetaJavaBuilder");
 }
 
 void GeneratorSetQtScript::dumpObjectTree() {

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -246,13 +246,8 @@ int main(int argc, char *argv[])
 
         /* Warn if standard directories are not found: */
         if (!requiredModules.isEmpty()) {
-            QString sep("");
-            QString errMsg("WARNING: missing core Qt modules:");
-
-            for (const QString &mod : requiredModules) {
-                errMsg += sep + " Qt" + mod;
-                sep = ",";
-            }
+            const QString errMsg("WARNING: missing core Qt modules: Qt" +
+                    requiredModules.join(",Qt"));
 
             if (args.contains("core-error"))
                 qFatal(errMsg.toLocal8Bit().constData());

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
             qWarning(
 "QTDIR environment variable not set. Assuming standard binary install using\n"
 "frameworks.");
-            foreach (const QString &mod, coreModules)
+            for (const QString &mod : coreModules)
                 includes << ("/Library/Frameworks/Qt" + mod + ".framework/Headers");
             includes << "/Library/Frameworks"; // this seems wrong
 #else
@@ -220,11 +220,11 @@ int main(int argc, char *argv[])
         QStringList dirList;
         QStringList requiredModules(coreModules);
 
-        foreach (const QString &dir, qtHeaders.split(QDir::listSeparator()))
+        for (const QString &dir : qtHeaders.split(QDir::listSeparator()))
             if (QDir(dir).exists())  {
                 QStringList remaining(requiredModules);
 
-                foreach (const QString &mod, requiredModules) {
+                for (const QString &mod : requiredModules) {
                     const QString modpath(dir + "/Qt" + mod);
                     if (QDir(modpath).exists()) {
                         includes << modpath;
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
             QString sep("");
             QString errMsg("WARNING: missing core Qt modules:");
 
-            foreach (const QString &mod, requiredModules) {
+            for (const QString &mod : requiredModules) {
                 errMsg += sep + " Qt" + mod;
                 sep = ",";
             }
@@ -269,7 +269,7 @@ int main(int argc, char *argv[])
 
     std::cout << "-------------------------------------------------------------" << std::endl;
     std::cout << "Scanning Qt headers from (in this order):" << std::endl;
-    foreach (const QString &dir, includes) {
+    for (const QString &dir : includes) {
         std::cout << "  " << dir.toUtf8().constData();
         if (!QDir(dir).exists())
             std::cout << " [DIRECTORY DOES NOT EXIST]";

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -149,21 +149,15 @@ int main(int argc, char *argv[])
     if (!minimal)
         includes << QString(".");
 
-#if defined(Q_OS_WIN32)
-    const char *path_splitter = ";";
-#else
-    const char *path_splitter = ":";
-#endif
-
     // Environment INCLUDE
     const QString includePath(getenv("INCLUDE"));
     if (!includePath.isEmpty())
-        includes += includePath.split(path_splitter);
+        includes += includePath.split(QDir::listSeparator());
 
     // Includes from the command line
     const QString commandLineIncludes(args.value("include-paths"));
     if (!commandLineIncludes.isEmpty())
-        includes += commandLineIncludes.split(path_splitter);
+        includes += commandLineIncludes.split(QDir::listSeparator());
 
     /* Allow coreModules to be specified on the command line (e.g. to add or
      * remove modules for an application specific build).
@@ -226,7 +220,7 @@ int main(int argc, char *argv[])
         QStringList dirList;
         QStringList requiredModules(coreModules);
 
-        foreach (const QString &dir, qtHeaders.split(path_splitter))
+        foreach (const QString &dir, qtHeaders.split(QDir::listSeparator()))
             if (QDir(dir).exists())  {
                 QStringList remaining(requiredModules);
 
@@ -340,11 +334,8 @@ int main(int argc, char *argv[])
 
 
 void displayHelp(GeneratorSet* generatorSet) {
-#if defined(Q_OS_WIN32)
-    char path_splitter = ';';
-#else
-    char path_splitter = ':';
-#endif
+    const QByteArray sep(QString(QDir::listSeparator()).toLocal8Bit());
+
     printf("Usage:\n  generator [options] header-file typesystem-file\n\n");
     printf("Available options:\n\n");
     printf("General:\n");
@@ -353,13 +344,13 @@ void displayHelp(GeneratorSet* generatorSet) {
            "  --help, -h or -?\n"
            "  --no-suppress-warnings\n"
            "  --output-directory=[dir]\n"
-           "  --include-paths=<path>[%c<path>%c...]\n"
-           "  --qt-headers=<path>[%c<path>%c...]\n"
+           "  --include-paths=<path>[%s<path>%s...]\n"
+           "  --qt-headers=<path>[%s<path>%s...]\n"
            "  --core-modules=module,...\n"
            "  --core-error\n"
            "  --minimal\n"
            "  --print-stdout\n\n",
-           path_splitter, path_splitter, path_splitter, path_splitter);
+           sep.constData(), sep.constData(), sep.constData(), sep.constData());
 
     printf("%s\n", qPrintable( generatorSet->usage()));
 
@@ -377,12 +368,12 @@ void displayHelp(GeneratorSet* generatorSet) {
 "  If core modules fail to be found a warning is issued unless --core-error\n"
 "  is given in which case the generator exits with an error.\n\n"
 "  Additional directories to be scanned are passed in the environment\n"
-"  variable INCLUDE and the --include-paths argument.  Both are '%c'\n"
+"  variable INCLUDE and the --include-paths argument.  Both are '%s'\n"
 "  separated lists of directories which are scanned before the core module\n"
 "  directories in the order given.\n\n"
 "  The current working directory is also scanned (first) unless --minimal is\n"
 "  given.\n",
-        coreModuleListDefault, path_splitter);
+        coreModuleListDefault, sep.constData());
 
     exit(1);
 }

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -212,7 +212,7 @@ int main(int argc, char *argv[])
          * in the qt-headers list.
          *
          * NOTE: use of a list here is intended for the project build workflows
-         * which apparently have to assemble the headers from difference
+         * which apparently have to assemble the headers from different
          * installation directories.  This could be avoided by using
          * --include-paths instead!
          *

--- a/generator/main.h
+++ b/generator/main.h
@@ -49,7 +49,8 @@
 
 struct Preprocess
 {
-    static bool preprocess(const QString &sourceFile, const QString &targetFile, const QString &commandLineIncludes = QString())
+    static bool preprocess(const QString &sourceFile, const QString &targetFile,
+            const QStringList &includes)
     {
         rpp::pp_environment env;
         rpp::pp preprocess(env);
@@ -68,51 +69,6 @@ struct Preprocess
         file.close();
         preprocess.operator() (ba.constData(), ba.constData() + ba.size(), null_out);
 
-        QStringList includes;
-        includes << QString(".");
-
-#if defined(Q_OS_WIN32)
-        const char *path_splitter = ";";
-#else
-        const char *path_splitter = ":";
-#endif
-
-        // Environment INCLUDE
-        QString includePath = getenv("INCLUDE");
-        if (!includePath.isEmpty())
-            includes += includePath.split(path_splitter);
-
-        // Includes from the command line
-        if (!commandLineIncludes.isEmpty())
-            includes += commandLineIncludes.split(path_splitter);
-
-        // Include Qt
-        QString qtdir = getenv ("QTDIR");
-        if (qtdir.isEmpty()) {
-#if defined(Q_OS_MAC)
-            qWarning("QTDIR environment variable not set. Assuming standard binary install using frameworks.");
-            QString frameworkDir = "/Library/Frameworks";
-            includes << (frameworkDir + "/QtXml.framework/Headers");
-            includes << (frameworkDir + "/QtNetwork.framework/Headers");
-            includes << (frameworkDir + "/QtCore.framework/Headers");
-            includes << (frameworkDir + "/QtGui.framework/Headers");
-            includes << (frameworkDir + "/QtOpenGL.framework/Headers");
-            includes << frameworkDir;
-#else
-            qWarning("QTDIR environment variable not set. This may cause problems with finding the necessary include files.");
-#endif
-        } else {
-            std::cout << "-------------------------------------------------------------" << std::endl;
-            std::cout << "Using QT at: " << qtdir.toLocal8Bit().constData() << std::endl;
-            std::cout << "-------------------------------------------------------------" << std::endl;
-            qtdir += "/include";
-            includes << (qtdir + "/QtXml");
-            includes << (qtdir + "/QtNetwork");
-            includes << (qtdir + "/QtCore");
-            includes << (qtdir + "/QtGui");
-            includes << (qtdir + "/QtOpenGL");
-            includes << qtdir;
-        }
         foreach (QString include, includes) {
             preprocess.push_include_path(QDir::toNativeSeparators(include).toStdString());
         }

--- a/generator/main.h
+++ b/generator/main.h
@@ -69,7 +69,7 @@ struct Preprocess
         file.close();
         preprocess.operator() (ba.constData(), ba.constData() + ba.size(), null_out);
 
-        foreach (QString include, includes) {
+        for (QString include : includes) {
             preprocess.push_include_path(QDir::toNativeSeparators(include).toStdString());
         }
 

--- a/generator/parser/binder.cpp
+++ b/generator/parser/binder.cpp
@@ -316,7 +316,7 @@ void Binder::declare_symbol(SimpleDeclarationAST *node, InitDeclaratorAST *init_
       fun->setVariadics (decl_cc.isVariadics ());
 
       // ... and the signature
-      foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+      for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
         {
           ArgumentModelItem arg = model()->create<ArgumentModelItem>();
           arg->setType(qualifyType(p.type, _M_context));
@@ -346,7 +346,7 @@ void Binder::declare_symbol(SimpleDeclarationAST *node, InitDeclaratorAST *init_
         {
           typeInfo.setFunctionPointer (true);
           decl_cc.run (init_declarator->declarator);
-          foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+          for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
             typeInfo.addArgument(p.type);
         }
 
@@ -395,7 +395,7 @@ void Binder::visitFunctionDefinition(FunctionDefinitionAST *node)
     }
 
   decl_cc.run(declarator);
-  foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters()) {
+  for (DeclaratorCompiler::Parameter p : decl_cc.parameters()) {
     if (p.type.isRvalueReference()) {
       //warnHere();
       //std::cerr << "** Skipping function with rvalue reference parameter: "
@@ -437,7 +437,7 @@ void Binder::visitFunctionDefinition(FunctionDefinitionAST *node)
 
   _M_current_function->setVariadics (decl_cc.isVariadics ());
 
-  foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+  for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
     {
       ArgumentModelItem arg = model()->create<ArgumentModelItem>();
       arg->setType(qualifyType(p.type, functionScope->qualifiedName()));
@@ -594,7 +594,7 @@ void Binder::visitTypedef(TypedefAST *node)
         {
           typeInfo.setFunctionPointer (true);
           decl_cc.run (init_declarator->declarator);
-          foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+          for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
             typeInfo.addArgument(p.type);
         }
 
@@ -950,7 +950,7 @@ TypeInfo Binder::qualifyType(const TypeInfo &type, const QStringList &context) c
 
           if (ClassModelItem klass = model_dynamic_cast<ClassModelItem> (scope))
             {
-              foreach (QString base, klass->baseClasses ())
+              for (QString base : klass->baseClasses ())
                 {
                   QStringList ctx = context;
                   ctx.removeLast();

--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -206,7 +206,7 @@ QString TypeInfo::toString() const
       tmp += QLatin1String(")");
     }
 
-  foreach (QString elt, arrayElements ())
+  for (QString elt : arrayElements ())
     {
       tmp += QLatin1String ("[");
       tmp += elt;
@@ -394,7 +394,7 @@ FunctionModelItem _ScopeModelItem::declaredFunction(FunctionModelItem item)
 {
   FunctionList function_list = findFunctions(item->name());
 
-  foreach (FunctionModelItem fun, function_list)
+  for (FunctionModelItem fun : function_list)
     {
       if (fun->isSimilar(item))
         return fun;

--- a/generator/parser/type_compiler.cpp
+++ b/generator/parser/type_compiler.cpp
@@ -131,7 +131,7 @@ QStringList TypeCompiler::cvString() const
 {
   QStringList lst;
 
-  foreach (int q, cv())
+  for (int q : cv())
     {
       if (q == Token_const)
         lst.append(QLatin1String("const"));

--- a/generator/prigenerator.cpp
+++ b/generator/prigenerator.cpp
@@ -145,7 +145,7 @@ void PriGenerator::generate()
         }
       
         file.stream << "HEADERS += \\\n";
-        foreach (const QString &entry, list) {
+        for (const QString &entry : list) {
           file.stream << "           $$PWD/" << entry << " \\\n";
         }
 
@@ -156,7 +156,7 @@ void PriGenerator::generate()
         if (compact) {
           list = compactFiles(list, ".cpp", m_out_dir + "/generated_cpp/" + folder, folder); 
         }
-        foreach (const QString &entry, list) {
+        for (const QString &entry : list) {
             file.stream << "           $$PWD/" << entry << " \\\n";
         }
         file.stream << "           $$PWD/" << folder << "_init.cpp\n";

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -60,7 +60,7 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
   QSet<QString> operatorCodes;
   AbstractMetaFunctionList returned;
   AbstractMetaFunctionList functions = cls->functions();
-  foreach (AbstractMetaFunction *function, functions) {
+  for (AbstractMetaFunction *function : functions) {
     if (function->originalName().startsWith("operator")) {
       QString op = function->originalName().mid(8);
       operatorCodes.insert(op);
@@ -228,7 +228,7 @@ void SetupGenerator::generate()
     while (pack.hasNext()) {
       pack.next();
       QList<const AbstractMetaClass*> list = pack.value();
-      foreach (const AbstractMetaClass *cls, list) {
+      for (const AbstractMetaClass *cls : list) {
         if (cls->typeEntry()->isPolymorphicBase()) {
           classes_with_polymorphic_id.append((AbstractMetaClass*)cls);
         }
@@ -256,7 +256,7 @@ void SetupGenerator::generate()
     }
 
     QString shortPackName;
-    foreach (QString comp, components) {
+    for (QString comp : components) {
       comp[0] = comp[0].toUpper();
       shortPackName += comp;
     }
@@ -332,7 +332,7 @@ void SetupGenerator::generate()
         shortPackName = shortPackName.mid(0, shortPackName.length()-strlen("builtin"));
       }
 
-      foreach (const AbstractMetaClass *cls, list) {
+      for (const AbstractMetaClass *cls : list) {
         if (cls->qualifiedCppName().contains("Ssl")) {
           s << "#ifndef QT_NO_SSL"  << endl;
         }
@@ -381,7 +381,7 @@ void SetupGenerator::generate()
         }
       }
       s << endl;
-      foreach (QString handler, polymorphicHandlers) {
+      for (QString handler : polymorphicHandlers) {
         s << "PythonQt::self()->addPolymorphicHandler(\""<< handler << "\", polymorphichandler_" << handler << ");" << endl;
       }
       s << endl;
@@ -412,14 +412,14 @@ QStringList SetupGenerator::writePolymorphicHandler(QTextStream &s, const QStrin
                                                     const AbstractMetaClassList &polybase, QList<const AbstractMetaClass*>& allClasses)
 {
   QStringList handlers;
-  foreach (AbstractMetaClass *cls, polybase) {
+  for (AbstractMetaClass *cls : polybase) {
     const ComplexTypeEntry *centry = cls->typeEntry();
     if (!centry->isPolymorphicBase())
       continue;
     bool isGraphicsItem = (cls->qualifiedCppName()=="QGraphicsItem");
 
     bool first = true;
-    foreach (const AbstractMetaClass *clazz, allClasses) {
+    for (const AbstractMetaClass *clazz : allClasses) {
       bool inherits = false;
       if (isGraphicsItem) {
         const AbstractMetaClass *currentClazz = clazz;

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -85,7 +85,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
 
   IncludeList list = meta_class->typeEntry()->extraIncludes();
   std::sort(list.begin(), list.end());
-  foreach (const Include &inc, list) {
+  for (const Include &inc : list) {
     ShellGenerator::writeInclude(s, inc);
   }  
   s << endl;
@@ -119,7 +119,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
     s << "}" << endl;
 
     AbstractMetaFunctionList virtualsForShell = getVirtualFunctionsForShell(meta_class);
-    foreach (const AbstractMetaFunction *fun, virtualsForShell) {
+    for (const AbstractMetaFunction *fun : virtualsForShell) {
       bool hasReturnValue = (fun->type());
       writeFunctionSignature(s, fun, meta_class, QString(),
         Option(OriginalName | ShowStatic | UnderscoreSpaces | UseIndexedName),
@@ -231,7 +231,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   if (meta_class->generateShellClass() || !meta_class->isAbstract()) {
 
     // write constructors
-    foreach (const AbstractMetaFunction *ctor, ctors) {
+    for (const AbstractMetaFunction *ctor : ctors) {
       if (ctor->isAbstract() || (!meta_class->generateShellClass() && !ctor->isPublic())) { continue; }
 
       s << meta_class->qualifiedCppName() << "* ";
@@ -365,7 +365,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
 void ShellImplGenerator::writeInjectedCode(QTextStream &s, const AbstractMetaClass *meta_class)
 {
   CodeSnipList code_snips = meta_class->typeEntry()->codeSnips();
-  foreach (const CodeSnip &cs, code_snips) {
+  for (const CodeSnip &cs : code_snips) {
     if (cs.language == TypeSystem::PyWrapperCode) {
       s << cs.code() << endl;
     }

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1272,7 +1272,7 @@ bool Handler::startElement(const QString &, const QString &n,
 
                 if (rc.action == ReferenceCount::Invalid) {
                     m_error = "unrecognized value for action attribute. supported actions:";
-                    foreach (QString action, actions.keys())
+                    for (QString action : actions.keys())
                         m_error += " " + action;
                 }
 
@@ -1557,8 +1557,8 @@ ContainerTypeEntry *TypeDatabase::findContainerType(const QString &name)
 
 PrimitiveTypeEntry *TypeDatabase::findTargetLangPrimitiveType(const QString &java_name)
 {
-    foreach (QList<TypeEntry *> entries, m_entries.values()) {
-        foreach (TypeEntry *e, entries) {
+    for (QList<TypeEntry *> entries : m_entries.values()) {
+        for (TypeEntry *e : entries) {
             if (e && e->isPrimitive()) {
                 PrimitiveTypeEntry *pe = static_cast<PrimitiveTypeEntry *>(e);
                 if (pe->targetLangName() == java_name && pe->preferredConversion())
@@ -1716,7 +1716,7 @@ bool TypeDatabase::isClassRejected(const QString &class_name)
     if (!m_rebuild_classes.isEmpty())
         return !m_rebuild_classes.contains(class_name);
 
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection &r : m_rejections)
         if (r.class_name == class_name && r.function_name == "*" && r.field_name == "*" && r.enum_name == "*") {
             return true;
         }
@@ -1725,7 +1725,7 @@ bool TypeDatabase::isClassRejected(const QString &class_name)
 
 bool TypeDatabase::isEnumRejected(const QString &class_name, const QString &enum_name)
 {
-    foreach (const TypeRejection &r, m_rejections) {
+    for (const TypeRejection &r : m_rejections) {
         if (r.enum_name == enum_name
             && (r.class_name == class_name || r.class_name == "*")) {
             return true;
@@ -1737,7 +1737,7 @@ bool TypeDatabase::isEnumRejected(const QString &class_name, const QString &enum
 
 bool TypeDatabase::isFunctionRejected(const QString &class_name, const QString &function_name)
 {
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection &r : m_rejections)
         if (r.function_name == function_name &&
             (r.class_name == class_name || r.class_name == "*"))
             return true;
@@ -1747,7 +1747,7 @@ bool TypeDatabase::isFunctionRejected(const QString &class_name, const QString &
 
 bool TypeDatabase::isFieldRejected(const QString &class_name, const QString &field_name)
 {
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection &r : m_rejections)
         if (r.field_name == field_name &&
             (r.class_name == class_name || r.class_name == "*"))
             return true;
@@ -1898,7 +1898,7 @@ QString FunctionModification::toString() const
     if (modifiers & Writable) str += QLatin1String("writable");
 
     if (modifiers & CodeInjection) {
-        foreach (CodeSnip s, snips) {
+        for (CodeSnip s : snips) {
             str += QLatin1String("\n//code injection:\n");
             str += s.code();
         }

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -1138,7 +1138,7 @@ public:
 
     TypeEntry *findType(const QString &name) const {
         QList<TypeEntry *> entries = findTypes(name);
-        foreach (TypeEntry *entry, entries) {
+        for (TypeEntry *entry : entries) {
             if (entry != 0 &&
                 (!entry->isPrimitive() || static_cast<PrimitiveTypeEntry *>(entry)->preferredTargetLangType())) {
                 return entry;
@@ -1190,7 +1190,7 @@ public:
         if (!m_suppressWarnings)
             return false;
 
-        foreach (const QString &_warning, m_suppressedWarnings) {
+        for (const QString &_warning : m_suppressedWarnings) {
             QString warning(QString(_warning).replace("\\*", "&place_holder_for_asterisk;"));
 
             QStringList segs = warning.split("*", Qt::SkipEmptyParts);
@@ -1233,7 +1233,7 @@ inline PrimitiveTypeEntry *TypeDatabase::findPrimitiveType(const QString &name)
 {
     QList<TypeEntry *> entries = findTypes(name);
 
-    foreach (TypeEntry *entry, entries) {
+    for (TypeEntry *entry : entries) {
         if (entry != 0 && entry->isPrimitive() && static_cast<PrimitiveTypeEntry *>(entry)->preferredTargetLangType())
             return static_cast<PrimitiveTypeEntry *>(entry);
     }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1631,7 +1631,7 @@ void PythonQt::removeSignalHandlers()
   QList<PythonQtSignalReceiver*> signalReceivers = _p->_signalReceivers.values();
 
   // just delete all signal receivers, they will remove themselves via removeSignalEmitter()
-  foreach(PythonQtSignalReceiver* receiver, signalReceivers) {
+  for (PythonQtSignalReceiver* receiver : signalReceivers) {
     delete receiver;
   }
   // just to be sure, clear the receiver map as well
@@ -1767,7 +1767,7 @@ void PythonQt::overwriteSysPath(const QStringList& paths)
   // Since Python uses os.path.sep at various places,
   // makse sure that we use the native path separators.
   QStringList nativePaths;
-  foreach(QString path, paths) {
+  for (QString path : paths) {
     nativePaths << QDir::toNativeSeparators(path);
   }
   PyModule_AddObject(sys, "path", PythonQtConv::QStringListToPyList(nativePaths));
@@ -2229,7 +2229,7 @@ const QMetaObject* PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper*
       PythonQtSignalFunctionObject* signal = (PythonQtSignalFunctionObject*)value;
       if (signal->_dynamicInfo) {
         signal->_dynamicInfo->name = PyString_AsString(key);
-        foreach(QByteArray sig, signal->_dynamicInfo->signatures) {
+        for (QByteArray sig : signal->_dynamicInfo->signatures) {
           builder.addSignal(signal->_dynamicInfo->name + "(" + sig + ")");
           needsMetaObject = true;
         }

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -485,7 +485,7 @@ QStringList PythonQtClassInfo::propertyList()
     }
   }
   QStringList members = memberList();
-  foreach(QString member, members) {
+  for (QString member : members) {
     if (member.startsWith("py_get_")) {
       l << member.mid(7);
     }
@@ -1067,7 +1067,7 @@ bool PythonQtClassInfo::supportsRichCompare()
       names << "__gt__";
       names << "__ge__";
     }
-    foreach (const QByteArray& name, names) {
+    for (const QByteArray& name : names) {
       if (member(name)._type == PythonQtMemberInfo::Slot) {
         // we found one of the operators, so we can support the type slot
         _typeSlots |= PythonQt::Type_RichCompare;

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -607,7 +607,7 @@ QStringList PythonQtSlotInfo::overloads(bool skipReturnValue) const
     }
     if (slotsWithSameArgs.size() > 1) {
       results << maxArgSlot->fullSignature(skipReturnValue, minSameArgs);
-      foreach(const PythonQtSlotInfo* o, slotsWithSameArgs) {
+      for(const PythonQtSlotInfo* o : slotsWithSameArgs) {
         list.removeOne(o);
       }
     } else {


### PR DESCRIPTION
This adds 'make generate' to generator/generator.pro using modified argument handling so that the Qt installed header directory can be used to build a new generated_cpp.  This is created in generator/ to avoid overwriting an existing user generated_cpp at the top level.

It also adds setContext calls to ReportHandler to improve the warning messages and calls fflush(stdout) at appropriate moments to fix the confusing mis-ordering of the pythonqt_generator output when it is piped to a file.