### PR TITLE
Handle constexpr, auto

### DIFF
--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -315,6 +315,8 @@ AbstractMetaFunction *AbstractMetaFunction::copy() const
     if (type())
         cpy->setType(type()->copy());
     cpy->setConstant(isConstant());
+    cpy->setConstexpr(isConstexpr());
+    cpy->setAuto(isAuto());
     cpy->setException(exception());
     cpy->setOriginalAttributes(originalAttributes());
 
@@ -366,6 +368,8 @@ QString AbstractMetaFunction::signature() const
 
     if (isConstant())
         s += " const";
+    if (isConstexpr())
+        s += " constexpr";
 
     return s;
 }
@@ -657,6 +661,8 @@ QString AbstractMetaFunction::minimalSignature() const
     minimalSignature += ")";
     if (isConstant())
         minimalSignature += "const";
+    if (isConstexpr())
+        minimalSignature += "constexpr";
 
     minimalSignature = TypeSystem::normalizedSignature(minimalSignature.toLocal8Bit().constData());
     m_cached_minimal_signature = minimalSignature;

--- a/generator/abstractmetalang.h
+++ b/generator/abstractmetalang.h
@@ -410,6 +410,7 @@ public:
 
     AbstractMetaFunction() :
           m_constant(false),
+          m_constexpr(false),
           m_invalid(false)
     {
     }
@@ -487,6 +488,12 @@ public:
     bool isConstant() const { return m_constant; }
     void setConstant(bool constant) { m_constant = constant; }
 
+    bool isConstexpr() const { return m_constexpr; }
+    void setConstexpr(bool constant) { m_constexpr = constant; }
+
+    bool isAuto() const { return m_auto; }
+    void setAuto(bool isAuto) { m_auto = isAuto; }
+
     QString exception() const { return m_exception; }
     void setException(const QString &exception) { m_exception = exception; }
     QString toString() const { return m_name; }
@@ -550,6 +557,8 @@ private:
     AbstractMetaArgumentList m_arguments;
     QString m_exception;
     uint m_constant                 : 1;
+    uint m_constexpr                : 1;
+    uint m_auto                     : 1;
     uint m_invalid                  : 1;
 };
 


### PR DESCRIPTION
These changes use the new and existing support inside the parser to handle constexpr in Qt6 files and to ignore (with a warning) 'auto' functions.