### PR TITLE
Qt6: fixes for removal of Qt5 types

### DIFF
--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -158,7 +158,10 @@ static QSet<QString> _builtinListTypes = QSet<QString>() << "QByteArray"
 << "QLineF"
 << "QPoint"
 << "QPointF"
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 << "QRegExp"
+#endif
+<< "QRegularExpression"
 << "QFont"
 << "QPixmap"
 << "QBrush"
@@ -175,7 +178,11 @@ static QSet<QString> _builtinListTypes = QSet<QString>() << "QByteArray"
 << "QPen"
 << "QTextLength"
 << "QTextFormat"
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
 << "QMatrix"
+#endif
+<< "QTransform"
+<< "QMatrix4x4"
 << "QVariant";
 
 static void addListRegistration(AbstractMetaType* type, QSet<QString>& output) {

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -435,7 +435,11 @@ bool ShellGenerator::isBuiltIn(const QString& name) {
     builtIn.insert("QKeySequence");
     builtIn.insert("QTextLength");
     builtIn.insert("QTextFormat");
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     builtIn.insert("QMatrix");
+#endif
+    builtIn.insert("QTransform");
+    builtIn.insert("QMatrix4x4");
     builtIn.insert("QDate");
     builtIn.insert("QTime");
     builtIn.insert("QDateTime");
@@ -449,7 +453,10 @@ bool ShellGenerator::isBuiltIn(const QString& name) {
     builtIn.insert("QLineF");
     builtIn.insert("QPoint");
     builtIn.insert("QPointF");
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     builtIn.insert("QRegExp");
+#endif
+    builtIn.insert("QRegularExpression");
   }
   return builtIn.contains(name);
 }

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -372,7 +372,7 @@ int PythonQtMethodInfo::nameToType(const char* name)
     _parameterTypeDict.insert("QLineF", QMetaType::QLineF);
     _parameterTypeDict.insert("QPoint", QMetaType::QPoint);
     _parameterTypeDict.insert("QPointF", QMetaType::QPointF);
-#if QT_VERSION < 0x060000
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     _parameterTypeDict.insert("QRegExp", QMetaType::QRegExp);
 #endif
     _parameterTypeDict.insert("QRegularExpression", QMetaType::QRegularExpression);
@@ -390,9 +390,11 @@ int PythonQtMethodInfo::nameToType(const char* name)
     _parameterTypeDict.insert("QKeySequence", QMetaType::QKeySequence);
     _parameterTypeDict.insert("QPen", QMetaType::QPen);
     _parameterTypeDict.insert("QTextLength", QMetaType::QTextLength);
-#if QT_VERSION < 0x060000
+#if QT_VERSION < QT_VERSION_CHECK(6,0,0)
     _parameterTypeDict.insert("QMatrix", QMetaType::QMatrix);
 #endif
+    _parameterTypeDict.insert("QMatrix4x4", QMetaType::QMatrix4x4);
+    _parameterTypeDict.insert("QTransform", QMetaType::QTransform);
     _parameterTypeDict.insert("QTextFormat", QMetaType::QTextFormat);
     _parameterTypeDict.insert("QVariant", PythonQtMethodInfo::Variant);
     // own special types... (none so far, could be e.g. ObjectList


### PR DESCRIPTION
Also add the alternate types that are available in Qt5 to replace the types deprecated in Qt5.14 (allows Qt5.15LTS users to make changes for compatibility with Qt6.)