### PR TITLE
Fix problems in Qt5.11 generator

### DIFF
--- a/build/common.prf
+++ b/build/common.prf
@@ -25,48 +25,34 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
   PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_$${QT_MAJOR_VERSION}$${QT_MINOR_VERSION}
 
   !exists($$PYTHONQT_GENERATED_PATH) {
-    contains( QT_MAJOR_VERSION, 5 ) {
-      contains( QT_MINOR_VERSION, 10 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
-      }
-      else:contains( QT_MINOR_VERSION, 11 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_511
-      }
-      else:contains( QT_MINOR_VERSION, 12 ) {
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_511
-      }
-      else:contains( QT_MINOR_VERSION, 1 ) {
+    # For Qt5 we know that the older generated wrappers work with the later
+    # versions, even (apparently) Qt5.15, so:
+    equals(QT_MAJOR_VERSION, 5) {
+      # Qt5: have 5.0, 5.3, 5.4, 5.6 and 5.11 at present:
+      lessThan(QT_MINOR_VERSION, 3) { # 5.1, 5.2
         PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_50
       }
-      else:contains( QT_MINOR_VERSION, 2 ) {
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_50
-      }
-  	  else:contains( QT_MINOR_VERSION, 3 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_53
-  	  }
-  	  else:contains( QT_MINOR_VERSION, 4 ) { 
+      else: lessThan(QT_MINOR_VERSION, 6) { # 5.5
         PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_54
-  	  }
-      else:contains( QT_MINOR_VERSION, 5 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_54
-  	  }
-      else:contains( QT_MINOR_VERSION, 6 ) { 
+      }
+      else: lessThan(QT_MINOR_VERSION, 11) { # 5.7, 5.8, 5.9, 5.10
         PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
       }
-      else:contains( QT_MINOR_VERSION, 7 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
-      }
-      else:contains( QT_MINOR_VERSION, 8 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
-      }
-      else:contains( QT_MINOR_VERSION, 9 ) { 
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
-      }
-      else {
-        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_56
+      else { # >5.11
+        # LATEST Qt5 generated files:
+        PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp_511
       }
     }
+
+    !exists($$PYTHONQT_GENERATED_PATH) {
+      error("No precompiled headers exist for Qt$${QT_VERSION}")
+    }
   }
+}
+
+!build_pass {
+  message("Qt version: Qt$${QT_VERSION}")
+  message("Using precompiled header files from $${PYTHONQT_GENERATED_PATH}")
 }
 
 VERSION = 3.2.0

--- a/build/common.prf
+++ b/build/common.prf
@@ -45,14 +45,14 @@ PYTHONQT_GENERATED_PATH = $$PWD/../generated_cpp
     }
 
     !exists($$PYTHONQT_GENERATED_PATH) {
-      error("No precompiled headers exist for Qt$${QT_VERSION}")
+      error("No generated sources exist for Qt$${QT_VERSION}")
     }
   }
 }
 
 !build_pass {
   message("Qt version: Qt$${QT_VERSION}")
-  message("Using precompiled header files from $${PYTHONQT_GENERATED_PATH}")
+  message("Using generated sources files from $${PYTHONQT_GENERATED_PATH}")
 }
 
 VERSION = 3.2.0

--- a/generator/qtscript_masterinclude.h
+++ b/generator/qtscript_masterinclude.h
@@ -38,7 +38,6 @@
 ** $QT_END_LICENSE$
 **
 ****************************************************************************/
-
 // We need to force the endianess in Qt5
 #define Q_BYTE_ORDER Q_LITTLE_ENDIAN
 
@@ -48,11 +47,29 @@
 #define QOPENGLFUNCTIONS_H
 #define QOPENGLEXTRAFUNCTIONS_H
 
-// our compiler can't handle the templates for singleShot (int Qt 5.12), but we can circumvent this with
-// Q_CLANG_QDOC for the moment:
-#define Q_CLANG_QDOC
-#include <QtCore/QTimer>
-#undef Q_CLANG_QDOC
+/* This must only be included after 'QT_NO_' definitions have been defined. */
+#include <QtCore/qglobal.h>
+
+/* NOTE: Qt5.12 and later (including Qt6) uses template functions for the
+ * static implementations of QTimer::singleShot() (the function, not the
+ * property).  The generator does not handle template functions so this work
+ * round is necessary.  Without this the QTimer::singleShot functions do not
+ * appear in the PythonQt interface.
+ *
+ * Unfortunately the work round breaks precompilation in Qt5.11 because it
+ * causes duplicate definitions of some text handling functions (because they
+ * really are duplicated if Q_CLANG_QDOC is turned on) so the change must
+ * be version specific.
+ *
+ * This work-round also does not work in Qt6 because Qt6 uses Q_QDOC and needs
+ * other fixes.
+ */
+#if QT_VERSION_MAJOR == 5 && QT_VERSION_MINOR > 11
+#   include <QtCore/QObject>  // included by QtCore/QTimer
+#   define Q_CLANG_QDOC
+#   include <QtCore/QTimer>
+#   undef Q_CLANG_QDOC
+#endif
 
 #include <QtCore/QtCore>
 #include <QtGui/QtGui>

--- a/generator/qtscript_masterinclude.h
+++ b/generator/qtscript_masterinclude.h
@@ -52,17 +52,19 @@
 
 /* NOTE: Qt5.12 and later (including Qt6) uses template functions for the
  * static implementations of QTimer::singleShot() (the function, not the
- * property).  The generator does not handle template functions so this work
- * round is necessary.  Without this the QTimer::singleShot functions do not
- * appear in the PythonQt interface.
+ * property).  The generator does not handle template functions.  Defining
+ * Q_CLANG_QDOC works around this by exposing the non-template forms that
+ * appear in the documentation at the same time as hiding the templates.
+ * Without this the QTimer::singleShot functions do not appear in the PythonQt
+ * interface.
  *
- * Unfortunately the work round breaks precompilation in Qt5.11 because it
- * causes duplicate definitions of some text handling functions (because they
- * really are duplicated if Q_CLANG_QDOC is turned on) so the change must
- * be version specific.
+ * Unfortunately the work around breaks precompilation in Qt5.11 because it
+ * causes duplicate definitions of some text handling functions (they really
+ * are duplicated if Q_CLANG_QDOC is turned on) so the change must be version
+ * specific.
  *
- * This work-round also does not work in Qt6 because Qt6 uses Q_QDOC and needs
- * other fixes.
+ * This does not work in Qt6 because Qt6 uses Q_QDOC for the documentation and
+ * needs other fixes.
  */
 #if QT_VERSION_MAJOR == 5 && QT_VERSION_MINOR > 11
 #   include <QtCore/QObject>  // included by QtCore/QTimer


### PR DESCRIPTION
The fix for Qt5.12 breaks pythonqt_generator for 5.11.  Patch includes better checking for precompiled headers and errors out early rather than failing when linking the src/ with mysterious missing symbols.