### PR TITLE
generator: improve error handling

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -39,6 +39,8 @@
 **
 ****************************************************************************/
 
+#include <cstdio>
+
 #include "main.h"
 #include "asttoxml.h"
 #include "reporthandler.h"
@@ -53,6 +55,8 @@ void displayHelp(GeneratorSet *generatorSet);
 #include <QDebug>
 int main(int argc, char *argv[])
 {
+    ReportHandler::setContext("Arguments");
+
     QScopedPointer<GeneratorSet> gs(GeneratorSet::getInstance());
 
     QString default_file = ":/trolltech/generator/qtscript_masterinclude.h";
@@ -135,11 +139,13 @@ int main(int argc, char *argv[])
     printf("Please wait while source files are being generated...\n");
 
     printf("Parsing typesystem file [%s]\n", qPrintable(typesystemFileName));
+    ReportHandler::setContext("Typesystem");
     if (!TypeDatabase::instance()->parseFile(typesystemFileName))
         qFatal("Cannot parse file: '%s'", qPrintable(typesystemFileName));
 
     printf("PreProcessing - Generate [%s] using [%s] and include-paths [%s]\n",
       qPrintable(pp_file), qPrintable(fileName), qPrintable(args.value("include-paths")));
+    ReportHandler::setContext("Preprocess");
     if (!Preprocess::preprocess(fileName, pp_file, args.value("include-paths"))) {
         fprintf(stderr, "Preprocessor failed on file: '%s'\n", qPrintable(fileName));
         return 1;
@@ -148,16 +154,19 @@ int main(int argc, char *argv[])
     if (args.contains("ast-to-xml")) {
       printf("Running ast-to-xml on file [%s] using pp_file [%s] and include-paths [%s]\n",
         qPrintable(fileName), qPrintable(pp_file), qPrintable(args.value("include-paths")));
+      ReportHandler::setContext(QString("AST-to-XML"));
       astToXML(pp_file);
       return 0;
     }
 
     printf("Building model using [%s]\n", qPrintable(pp_file));
+    ReportHandler::setContext("Build");
     gs->buildModel(pp_file);
     if (args.contains("dump-object-tree")) {
         gs->dumpObjectTree();
         return 0;
     }
+    ReportHandler::setContext("Generate");
     printf("%s\n", qPrintable(gs->generate()));
 
     printf("Done, %d warnings (%d known issues)\n", ReportHandler::warningCount(),


### PR DESCRIPTION
This ensures that printf() in the generator does not get file buffered (and therefore delayed relative to stderr) when piping output to a file and provides ReportHandler "context" for ReportHandler warnings.