### PR TITLE
generator: AbstractMetaClassList: correct sorting

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -39,8 +39,6 @@
 **
 ****************************************************************************/
 
-#include <algorithm> // for std::sort
-
 #include "abstractmetabuilder.h"
 #include "reporthandler.h"
 
@@ -380,15 +378,9 @@ void AbstractMetaBuilder::fixQObjectForScope(TypeDatabase *types,
     }
 }
 
-static bool class_less_than(AbstractMetaClass *a, AbstractMetaClass *b)
-{
-    return a->name() < b->name();
-}
-
-
 void AbstractMetaBuilder::sortLists()
 {
-   std::sort(m_meta_classes.begin(), m_meta_classes.end(), class_less_than);
+   m_meta_classes.sort();
    for (AbstractMetaClass *cls :  m_meta_classes) {
         cls->sortFunctions();
    }
@@ -2491,7 +2483,7 @@ AbstractMetaClassList AbstractMetaBuilder::classesTopologicalSorted() const
     AbstractMetaClassList res;
 
     AbstractMetaClassList classes = m_meta_classes;
-    std::sort(classes.begin(), classes.end());
+    classes.sort();
 
     QSet<AbstractMetaClass*> noDependency;
     QHash<AbstractMetaClass*, QSet<AbstractMetaClass* >* > hash;

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -39,7 +39,7 @@
 **
 ****************************************************************************/
 
-#include <algorithm> // for std::sort
+#include <algorithm> // for std::stable_sort
 
 #include "abstractmetalang.h"
 #include "reporthandler.h"
@@ -2022,4 +2022,10 @@ AbstractMetaClass *AbstractMetaClassList::findClass(const QString &name) const
     }
 
     return 0;
+}
+
+
+void AbstractMetaClassList::sort(void)
+{
+   std::stable_sort(begin(), end(), AbstractMetaClass::less_than);
 }

--- a/generator/abstractmetalang.h
+++ b/generator/abstractmetalang.h
@@ -71,6 +71,7 @@ public:
     AbstractMetaClass *findClass(const QString &name) const;
     AbstractMetaEnumValue *findEnumValue(const QString &string) const;
     AbstractMetaEnum *findEnum(const EnumTypeEntry *entry) const;
+    void sort();
 
 };
 
@@ -833,6 +834,11 @@ public:
     bool isTypeAlias() const { return m_is_type_alias; }
     bool operator <(const AbstractMetaClass &a) const {
       return qualifiedCppName() < a.qualifiedCppName();
+    }
+
+    static bool less_than(const AbstractMetaClass *cl,
+            const AbstractMetaClass *cr) {
+        return cl->name() < cr->name();
     }
 
 private:

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -39,7 +39,6 @@
 **
 ****************************************************************************/
 
-#include <algorithm> // for std::stable_sort, std::sort
 #include "generator.h"
 #include "reporthandler.h"
 #include "fileout.h"
@@ -62,7 +61,7 @@ void Generator::generate()
         return;
     }
 
-    std::stable_sort(m_classes.begin(), m_classes.end());
+    m_classes.sort();
 
     foreach (AbstractMetaClass *cls, m_classes) {
         if (!shouldGenerate(cls))
@@ -86,7 +85,7 @@ void Generator::printClasses()
     QTextStream s(stdout);
 
     AbstractMetaClassList classes = m_classes;
-    std::sort(classes.begin(), classes.end());
+    classes.sort();
 
     foreach (AbstractMetaClass *cls, classes) {
         if (!shouldGenerate(cls))

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -39,7 +39,7 @@
 **
 ****************************************************************************/
 
-#include <algorithm> // for std::sort
+#include <algorithm> // for std::sort, std::stable_sort
 
 #include "setupgenerator.h"
 #include "shellgenerator.h"
@@ -137,11 +137,6 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
 #endif
   std::sort(result.begin(), result.end());
   return result;
-}
-
-static bool class_less_than(const AbstractMetaClass *a, const AbstractMetaClass *b)
-{
-  return a->name() < b->name();
 }
 
 static QSet<QString> _builtinListTypes = QSet<QString>() << "QByteArray"
@@ -242,7 +237,7 @@ void SetupGenerator::generate()
       }
     }
   }
-  std::sort(classes_with_polymorphic_id.begin(), classes_with_polymorphic_id.end(), class_less_than);
+  classes_with_polymorphic_id.sort();
 
   QHashIterator<QString, QList<const AbstractMetaClass*> > pack(packHash);
   while (pack.hasNext()) {
@@ -250,7 +245,7 @@ void SetupGenerator::generate()
     QList<const AbstractMetaClass*> list = pack.value();
     if (list.isEmpty())
       continue;
-    std::sort(list.begin(), list.end(), class_less_than);
+    std::stable_sort(list.begin(), list.end(), AbstractMetaClass::less_than);
 
     QString packKey = pack.key();
     QString packName = pack.key();


### PR DESCRIPTION
In some places the list was sorted by pointer (resulting in a random sort) in other cases by name, sometimes with stable_sort, sometimes not. Now sort by name and use a stable_sort.