### PR TITLE
Improve debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,6 @@ generate.bat
 generator/release
 
 /.vs/
+*/.vs
 */debug/*
 */release/*

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -47,6 +47,7 @@
 #include "typesystem.h"
 #include "generatorset.h"
 #include "fileout.h"
+#include "control.h"
 
 #include <QDir>
 
@@ -100,6 +101,10 @@ int main(int argc, char *argv[])
             ReportHandler::setDebugLevel(ReportHandler::MediumDebug);
         else if (level == "full")
             ReportHandler::setDebugLevel(ReportHandler::FullDebug);
+    }
+
+    if (args.contains("print-parser-errors")) {
+      Control::setPrintErrors(true);
     }
 
     if (args.contains("dummy")) {
@@ -184,6 +189,7 @@ void displayHelp(GeneratorSet* generatorSet) {
     printf("Available options:\n\n");
     printf("General:\n");
     printf("  --debug-level=[sparse|medium|full]        \n"
+           "  --print-parser-errors                     \n"
            "  --dump-object-tree                        \n"
            "  --help, -h or -?                          \n"
            "  --no-suppress-warnings                    \n"

--- a/generator/parser/ast.cpp
+++ b/generator/parser/ast.cpp
@@ -48,5 +48,5 @@ QString AST::toString(TokenStream *stream) const
 {
     const Token &tk = stream->token((int) start_token);
     const Token &end_tk = stream->token ((int) end_token);
-    return QString::fromLatin1(tk.text + tk.position, end_tk.position - tk.position);
+    return QString::fromLatin1(tk.text + tk.position, static_cast<int>(end_tk.position - tk.position));
 }

--- a/generator/parser/binder.cpp
+++ b/generator/parser/binder.cpp
@@ -817,7 +817,7 @@ void Binder::visitQEnums(QEnumsAST *node)
   const Token &start = _M_token_stream->token((int) node->start_token);
   const Token &end = _M_token_stream->token((int) node->end_token);
   QStringList enum_list = QString::fromLatin1(start.text + start.position,
-                                              end.position - start.position).split(' ');
+                                              static_cast<int>(end.position - start.position)).split(' ');
 
   ScopeModelItem scope = currentScope();
   for (int i = 0; i < enum_list.size(); ++i) {
@@ -833,7 +833,7 @@ void Binder::visitQProperty(QPropertyAST *node)
     const Token &start = _M_token_stream->token((int) node->start_token);
     const Token &end = _M_token_stream->token((int) node->end_token);
     QString property = QString::fromLatin1(start.text + start.position,
-                                           end.position - start.position);
+                                           static_cast<int>(end.position - start.position));
     _M_current_class->addPropertyDeclaration(property);
 }
 

--- a/generator/parser/control.cpp
+++ b/generator/parser/control.cpp
@@ -43,6 +43,8 @@
 #include "control.h"
 #include "lexer.h"
 
+bool Control::_M_printErrors = false;
+
 Control::Control()
   : current_context(0),
     _M_skipFunctionBody(false),
@@ -141,7 +143,10 @@ void Control::clearErrorMessages ()
 
 void Control::reportError (const ErrorMessage &errmsg)
 {
-    _M_error_messages.append(errmsg);
+  _M_error_messages.append(errmsg);
+  if (_M_printErrors) {
+    printf("%s (%s:%d:%d)\n", qPrintable(errmsg.message()), qPrintable(errmsg.fileName()), errmsg.line(), errmsg.column());
+  }
 }
 
 // kate: space-indent on; indent-width 2; replace-tabs on;

--- a/generator/parser/control.h
+++ b/generator/parser/control.h
@@ -133,6 +133,9 @@ public:
   void declareTypedef(const NameSymbol *name, Declarator *d);
   bool isTypedef(const NameSymbol *name) const;
 
+  static bool printErrors() { return _M_printErrors; }
+  static void setPrintErrors(bool on) { _M_printErrors = on; }
+
   void reportError (const ErrorMessage &errmsg);
   QList<ErrorMessage> errorMessages () const;
   void clearErrorMessages ();
@@ -141,6 +144,7 @@ private:
   NameTable name_table;
   QHash<const NameSymbol*, Declarator*> stl_typedef_table;
   bool _M_skipFunctionBody;
+  static bool _M_printErrors;
   Lexer *_M_lexer;
   Parser *_M_parser;
 

--- a/generator/parser/lexer.h
+++ b/generator/parser/lexer.h
@@ -168,10 +168,10 @@ public:
   inline std::size_t matchingBrace(std::size_t i) const
   { return tokens[i].extra.right_brace; }
 
-  inline Token &operator[](int i)
+  inline Token &operator[](std::size_t i)
   { return tokens[i]; }
 
-  inline const Token &token(int i) const
+  inline const Token &token(std::size_t i) const
   { return tokens[i]; }
 
 private:

--- a/generator/parser/parser.h
+++ b/generator/parser/parser.h
@@ -189,7 +189,7 @@ public:
   bool skipUntilStatement();
   bool skip(int l, int r);
 
-  void advance();
+  void nextToken();
 
   // private:
   TokenStream token_stream;
@@ -200,12 +200,18 @@ public:
 
 private:
   QString tokenText(AST *) const;
+  void keepTrackDebug();
 
   LocationManager _M_location;
   Control *control;
   Lexer lexer;
   pool *_M_pool;
   bool _M_block_errors;
+
+  QString _currentFile;
+  int _currentLine{};
+  int _currentColumn{};
+  const char* _currentToken{};
 
 private:
   Parser(const Parser& source);


### PR DESCRIPTION
Add some code that helps with debugging the problems that the generator has with newer Qt versions:

- command line option for printing parser errors
- keep track of the current (approximate) source code location, and make current token readable in debugger (only in Debug mode)