### PR TITLE
Improve CI with sanitizers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,11 +53,12 @@ jobs:
         echo ======= SYSTEM INFO ========
         uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
         echo ============================
-        qmake -r PythonQt.pro CONFIG+=release CONFIG+=sanitizer CONFIG+=sanitize_undefined \
+        qmake -r PythonQt.pro CONFIG+=release CONFIG+=force_debug_info \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
         PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
         PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
         make -j 2
-        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
       
     - name: Generate Wrappers
@@ -66,6 +67,7 @@ jobs:
         mkdir /usr/include/qt5; ln -s /usr/include/x86_64-linux-gnu/qt5 /usr/include/qt5/include
         export QTDIR=/usr/include/qt5
         cd generator
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
         ./pythonqt_generator
 
     - name: Upload Wrappers
@@ -196,13 +198,13 @@ jobs:
         for i in "python${{ steps.versions.outputs.PYTHON_VERSION_SHORT }}-embed" "python${{ steps.versions.outputs.PYTHON_VERSION_SHORT }}" \
                  "python${PYTHON_VERSION_MAJOR}-embed" "python${PYTHON_VERSION_MAJOR}"
         do if pkg-config --exists "$i"; then PYTHON_PKGCONFIG_NAME="$i"; break; fi; done
-        qmake CONFIG+=${{ matrix.configuration }} CONFIG+=sanitizer CONFIG+=sanitize_undefined \
+        qmake CONFIG+=${{ matrix.configuration }} CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
           PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }} \
           PYTHON_DIR="$pythonLocation" \
           PKGCONFIG+=$PYTHON_PKGCONFIG_NAME \
           -r PythonQt.pro
         make -j 2
-        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
 
     - name: Generate Wrappers
@@ -210,6 +212,7 @@ jobs:
       run: |
         cd generator
         # workaround to allow to find the Qt include dirs for installed standard qt packages
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
         QTDIR=-UNDEFINED- ./pythonqt_generator --include-paths=$Qt5_Dir/lib
 
     - name: Upload Wrappers

--- a/generator/parser/tokens.cpp
+++ b/generator/parser/tokens.cpp
@@ -41,6 +41,7 @@
 
 
 #include <QtCore/qglobal.h>
+#include <iostream>
 
 #include "tokens.h"
 
@@ -152,7 +153,8 @@ static char const * const _S_token_names[] = {
   "xor",
   "xor_eq",
   "Q_ENUMS",
-  "Q_ENUM"
+  "Q_ENUM",
+  "Q_INVOKABLE"
 };
 
 static char _S_printable[][2] = {
@@ -254,6 +256,18 @@ static char _S_printable[][2] = {
   { char(127), '\0' },
 };
 
+int check_tokens_consistency()
+{
+  if (sizeof(_S_token_names) / sizeof(_S_token_names[0]) != TOKEN_KIND_COUNT - Token_K_DCOP)
+    {
+      std::cerr << "** ERROR enum TOKEN_KIND and _S_token_names are not consistent" << std::endl;
+      abort();
+    }
+  return 0;
+}
+
+static int tokens_consistency = check_tokens_consistency();
+
 char const *token_name(int token)
 {
   if (token == 0)
@@ -264,9 +278,9 @@ char const *token_name(int token)
     {
       return _S_printable[token - 32];
     }
-  else if (token >= 1000)
+  else if (token >= Token_K_DCOP)
     {
-      return _S_token_names[token - 1000];
+      return _S_token_names[token - Token_K_DCOP];
     }
 
   Q_ASSERT(0);


### PR DESCRIPTION
- Add sanitizers to the PythonQt testing step and the generator step. Due to the large number of leaks, leak_detects is temporarily disabled.
- Add consistency check between TOKEN_KIND enum and _S_token_names array, because otherwise CI fails with the ASan error "Array index out of bounds".
