### PR TITLE
Reduce memory leaks

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -150,6 +150,11 @@ AbstractMetaBuilder::AbstractMetaBuilder()
 {
 }
 
+AbstractMetaBuilder::~AbstractMetaBuilder()
+{
+    qDeleteAll(m_meta_classes);
+}
+
 void AbstractMetaBuilder::checkFunctionModifications()
 {
     TypeDatabase *types = TypeDatabase::instance();

--- a/generator/abstractmetabuilder.h
+++ b/generator/abstractmetabuilder.h
@@ -62,7 +62,7 @@ public:
     };
 
     AbstractMetaBuilder();
-    virtual ~AbstractMetaBuilder() {};
+    virtual ~AbstractMetaBuilder();
 
     AbstractMetaClassList classes() const { return m_meta_classes; }
     AbstractMetaClassList classesTopologicalSorted() const;


### PR DESCRIPTION
A step towards #138.
Generator behaviour doesn't change (for example, based on wrappers generated for qt 5.12 before and after this fix), but the amount of leaked memory decreases by a third (from 57 to 37 MB). The measurements were carried out on the make_generator_work_for_5.15 branch.
I will try to continue to reduce the number of leaks in the near future.
