### PR TITLE
Qt5 latest workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
         PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
         PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
-        make -j 2
+        make -j $(nproc)
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
       
@@ -120,7 +120,7 @@ jobs:
         qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} \
           PYTHON_VERSION=$(python${PYTHON_VERSION_SUFFIX} --version | cut -d " " -f 2 | cut -d "." -f1,2) \
           PYTHON_DIR=$(which python${PYTHON_VERSION_SUFFIX} | xargs dirname | xargs dirname)
-        make -j 2 && make check TESTARGS="-platform offscreen"
+        make -j $(nproc) && make check TESTARGS="-platform offscreen"
 
     - name: Generate Wrappers
       run: |
@@ -203,7 +203,7 @@ jobs:
           PYTHON_DIR="$pythonLocation" \
           PKGCONFIG+=$PYTHON_PKGCONFIG_NAME \
           -r PythonQt.pro
-        make -j 2
+        make -j $(nproc)
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
 

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,0 +1,71 @@
+name: Latest Qt5/6
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+      
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        qt-version: [ '5.*', '6.*']
+        python-version: [ '3.12' ]
+    runs-on: ubuntu-latest
+    steps:
+      
+    - name: Install Qt ${{matrix.qt-version}}
+      uses: jurplel/install-qt-action@v3
+      with:
+        version: ${{ matrix.qt-version }}
+        modules: ${{startsWith(matrix.qt-version, '6') && 'qt5compat' || '' }}
+        archives: 'qtmultimedia qtlinuxextras qtbase qttools icu qtwayland'
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: '${{ matrix.python-version }}'
+
+    - name: Checkout PythonQt
+      uses: actions/checkout@v3
+
+    - name: Set environment
+      run: |
+        QT_VERSION_MAJOR=$(cut -f 1 -d . <<< "${{matrix.qt-version}}")
+        echo "QT_VERSION_MAJOR=$QT_VERSION_MAJOR" >> $GITHUB_ENV
+        QTDIR=$(eval echo "\$Qt${QT_VERSION_MAJOR}_DIR")
+        echo "QTDIR=$QTDIR" >> $GITHUB_ENV
+        echo "$QTDIR/bin" >> $GITHUB_PATH
+        echo "$pythonLocation/bin" >> $GITHUB_PATH
+
+    - name: Build PythonQt
+      run: |
+        echo ======= SYSTEM INFO ========
+        uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
+        echo ============================
+        qmake -r PythonQt.pro CONFIG+=release CONFIG+=force_debug_info \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
+        PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+        PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+        make -j $(nproc)
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+          make check TESTARGS="-platform offscreen"
+      
+    - name: Generate Wrappers
+      run: |
+        cd generator
+        UBSAN_OPTIONS="halt_on_error=1" \
+        ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        ./pythonqt_generator
+
+    - name: Upload Wrappers
+      uses: actions/upload-artifact@v3
+      with:
+        name: wrappers_ubuntu_${{startsWith(matrix.qt-version, '6') && '6' || '5' }}-latest
+        path: generated_cpp

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,4 +1,4 @@
-name: Latest Qt5/6
+name: Latest Qt5
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt-version: [ '5.*', '6.*']
+        qt-version: [ '5.12.*' ]
         python-version: [ '3.12' ]
     runs-on: ubuntu-latest
     steps:
@@ -24,7 +24,6 @@ jobs:
       uses: jurplel/install-qt-action@v3
       with:
         version: ${{ matrix.qt-version }}
-        modules: ${{startsWith(matrix.qt-version, '6') && 'qt5compat' || '' }}
         archives: 'qtmultimedia qtlinuxextras qtbase qttools icu qtwayland'
 
     - name: Setup Python ${{ matrix.python-version }}
@@ -67,5 +66,5 @@ jobs:
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3
       with:
-        name: wrappers_ubuntu_${{startsWith(matrix.qt-version, '6') && '6' || '5' }}-latest
+        name: wrappers_ubuntu_5-latest
         path: generated_cpp

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -43,19 +43,13 @@ jobs:
         echo "$QTDIR/bin" >> $GITHUB_PATH
         echo "$pythonLocation/bin" >> $GITHUB_PATH
 
-    - name: Build PythonQt
+    - name: Build generator
       run: |
-        echo ======= SYSTEM INFO ========
-        uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
-        echo ============================
-        qmake -r PythonQt.pro CONFIG+=release CONFIG+=force_debug_info \
-        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
-        PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
-        PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+        cd generator
+        qmake -r generator.pro CONFIG+=release CONFIG+=force_debug_info \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address
         make -j $(nproc)
-        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
-          make check TESTARGS="-platform offscreen"
-      
+
     - name: Generate Wrappers
       run: |
         cd generator
@@ -68,3 +62,16 @@ jobs:
       with:
         name: wrappers_ubuntu_5-latest
         path: generated_cpp
+
+    - name: Build PythonQt
+      run: |
+        echo ======= SYSTEM INFO ========
+        uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
+        echo ============================
+        qmake -r PythonQt.pro CONFIG+=release CONFIG+=force_debug_info \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
+        PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
+        PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
+        make -j $(nproc)
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+          make check TESTARGS="-platform offscreen"

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,4 +1,4 @@
-name: Latest Qt5
+name: Qt5 check generated_cpp
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        qt-version: [ '5.12.*' ]
+        qt-version: [ '5.12.*', '5.15.*' ]
         python-version: [ '3.12' ]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
CI workflow for Qt5 latest builds on Ubuntu-latest worker based on #149.
Adds a new step that allows to build PythonQt with freshly generated code.
Now contains qt 5.12 version for testing a new scenario, but easily can be changed to 5.* (equivalent to 5.15) when PR #146 is merged.