### PR TITLE
Add version qualifiers to typesystem XML files

### DIFF
--- a/generator/main.h
+++ b/generator/main.h
@@ -49,25 +49,9 @@
 
 struct Preprocess
 {
-    static bool preprocess(const QString &sourceFile, const QString &targetFile, const QString &commandLineIncludes = QString())
+
+    static QStringList getIncludeDirectories(const QString& commandLineIncludes)
     {
-        rpp::pp_environment env;
-        rpp::pp preprocess(env);
-
-        rpp::pp_null_output_iterator null_out;
-
-        const char *ppconfig = ":/trolltech/generator/parser/rpp/pp-qt-configuration";
-
-        QFile file(ppconfig);
-        if (!file.open(QFile::ReadOnly)) {
-            fprintf(stderr, "Preprocessor configuration file not found '%s'\n", ppconfig);
-            return false;
-        }
-
-        QByteArray ba = file.readAll();
-        file.close();
-        preprocess.operator() (ba.constData(), ba.constData() + ba.size(), null_out);
-
         QStringList includes;
         includes << QString(".");
 
@@ -113,7 +97,29 @@ struct Preprocess
             includes << (qtdir + "/QtOpenGL");
             includes << qtdir;
         }
-        foreach (QString include, includes) {
+        return includes;
+    }
+
+    static bool preprocess(const QString &sourceFile, const QString &targetFile, const QString &commandLineIncludes = QString())
+    {
+        rpp::pp_environment env;
+        rpp::pp preprocess(env);
+
+        rpp::pp_null_output_iterator null_out;
+
+        const char *ppconfig = ":/trolltech/generator/parser/rpp/pp-qt-configuration";
+
+        QFile file(ppconfig);
+        if (!file.open(QFile::ReadOnly)) {
+            fprintf(stderr, "Preprocessor configuration file not found '%s'\n", ppconfig);
+            return false;
+        }
+
+        QByteArray ba = file.readAll();
+        file.close();
+        preprocess.operator() (ba.constData(), ba.constData() + ba.size(), null_out);
+
+        foreach (QString include, getIncludeDirectories(commandLineIncludes)) {
             preprocess.push_include_path(QDir::toNativeSeparators(include).toStdString());
         }
 

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -216,7 +216,6 @@ private:
     bool importFileElement(const QXmlAttributes &atts);
     bool convertBoolean(const QString &, const QString &, bool);
     bool qtVersionMatches(const QXmlAttributes& atts, bool& ok);
-    unsigned int qtVersionFromString(const QString& value, bool& ok);
 
     TypeDatabase *m_database;
     StackElement* current;
@@ -475,7 +474,7 @@ bool Handler::qtVersionMatches(const QXmlAttributes& atts, bool& ok)
   ok = true;
   int beforeIndex = atts.index("before-version");
   if (beforeIndex >= 0) {
-    uint beforeVersion = qtVersionFromString(atts.value(beforeIndex), ok);
+    uint beforeVersion = TypeSystem::qtVersionFromString(atts.value(beforeIndex), ok);
     if (ok) {
       if (m_qtVersion >= beforeVersion) {
         return false;
@@ -487,7 +486,7 @@ bool Handler::qtVersionMatches(const QXmlAttributes& atts, bool& ok)
   }
   int afterIndex = atts.index("after-version"); // after-version really means this version or any version after
   if (afterIndex >= 0) {
-    uint afterVersion = qtVersionFromString(atts.value(afterIndex), ok);
+    uint afterVersion = TypeSystem::qtVersionFromString(atts.value(afterIndex), ok);
     if (ok) {
       if (m_qtVersion < afterVersion) {
         return false;
@@ -498,29 +497,6 @@ bool Handler::qtVersionMatches(const QXmlAttributes& atts, bool& ok)
     }
   }
   return true;
-}
-
-uint Handler::qtVersionFromString(const QString& value, bool& ok)
-{
-  ok = true;
-  QList<uint> values;
-  for (QString dotValue: value.split('.'))
-  {
-    dotValue = dotValue.trimmed();
-    bool ok2;
-    values.append(dotValue.toUInt(&ok2));
-    if (!ok2) {
-      ok = false;
-    }
-  }
-  uint result = values[0] << 16;
-  if (values.size() >= 2) {
-    result += values[1] << 8;
-  }
-  if (values.size() >= 3) {
-    result += values[2];
-  }
-  return result;
 }
 
 bool Handler::startElement(const QString &, const QString &n,
@@ -2133,3 +2109,27 @@ QByteArray TypeSystem::normalizedSignature(const char* signature)
   result.replace("QStringList<QString>", "QStringList");
   return result;
 }
+
+unsigned int TypeSystem::qtVersionFromString(const QString& value, bool& ok)
+{
+  ok = true;
+  QList<uint> values;
+  for (QString dotValue : value.split('.'))
+  {
+    dotValue = dotValue.trimmed();
+    bool ok2;
+    values.append(dotValue.toUInt(&ok2));
+    if (!ok2) {
+      ok = false;
+    }
+  }
+  uint result = values[0] << 16;
+  if (values.size() >= 2) {
+    result += values[1] << 8;
+  }
+  if (values.size() >= 3) {
+    result += values[2];
+  }
+  return result;
+}
+

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -1216,7 +1216,7 @@ public:
     static QString globalNamespaceClassName(const TypeEntry *te);
     QString filename() const { return "typesystem.txt"; }
 
-    bool parseFile(const QString &filename, bool generate = true);
+    bool parseFile(const QString &filename, unsigned int qtVersion, bool generate = true);
 
 private:
     bool m_suppressWarnings;

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -167,6 +167,9 @@ namespace TypeSystem {
 
     //! A better normalized signature, which takes care of PODs with the same name
     QByteArray normalizedSignature(const char* signature);
+
+    //! Determine version ID from version string
+    unsigned int qtVersionFromString(const QString& value, bool& ok);
 }
 
 struct ReferenceCount

--- a/generator/typesystem_core.xml
+++ b/generator/typesystem_core.xml
@@ -894,10 +894,12 @@
       <remove/>
     </modify-function>
 
-    <modify-function signature="intersect(const QRect&amp;)const" remove="all"/>
-    <!--### Obsolete in 4.3-->
-    <modify-function signature="unite(const QRect&amp;)const" remove="all"/>
-    <!--### Obsolete in 4.3-->
+    <group before-version="6">
+      <modify-function signature="intersect(const QRect&amp;)const" remove="all"/>
+      <!--### Obsolete in 4.3-->
+      <modify-function signature="unite(const QRect&amp;)const" remove="all"/>
+      <!--### Obsolete in 4.3-->
+    </group>
   </value-type>
 
   <value-type name="QRectF">
@@ -1281,7 +1283,8 @@
     <modify-function signature="unmap(unsigned char*)" remove="all"/>
     <!-- Can't provide same API and performance -->
   
-    <modify-function signature="open(int,QFlags&lt;QIODevice::OpenModeFlag&gt;)" remove="all"/>
+    <modify-function signature="open(int,QFlags&lt;QIODevice::OpenModeFlag&gt;)" remove="all" before-version="6"/>
+    <modify-function signature="open(int,QFlags&lt;QIODeviceBase::OpenModeFlag&gt;,QFlags&lt;QFileDevice::FileHandleFlag&gt;)" remove="all" after-version="6"/>
     <modify-function signature="decodeName(const char*)" remove="all"/>
     <modify-function signature="map(qint64,qint64,QFile::MemoryMapFlags)" remove="all"/>
     <modify-function signature="unmap(uchar*)" remove="all"/>

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -2082,18 +2082,20 @@ PyObject* constScanLine(QImage* image, int line) {
       </modify-argument>
     </modify-function>
     
-    <modify-function signature="setItemHidden(const QListWidgetItem*,bool)">
-        <remove/>
-    </modify-function>
-    <modify-function signature="isItemHidden(const QListWidgetItem*)const">
-        <remove/>
-    </modify-function>
-    <modify-function signature="setItemSelected(const QListWidgetItem*,bool)">
-        <remove/>
-    </modify-function>
-    <modify-function signature="isItemSelected(const QListWidgetItem*)const">
-        <remove/>
-    </modify-function>
+    <group before-version="6">
+      <modify-function signature="setItemHidden(const QListWidgetItem*,bool)">
+          <remove/>
+      </modify-function>
+      <modify-function signature="isItemHidden(const QListWidgetItem*)const">
+          <remove/>
+      </modify-function>
+      <modify-function signature="setItemSelected(const QListWidgetItem*,bool)">
+          <remove/>
+      </modify-function>
+      <modify-function signature="isItemSelected(const QListWidgetItem*)const">
+          <remove/>
+      </modify-function>
+    </group>
     <modify-function signature="mimeData(const QList&lt;QListWidgetItem*&gt;)const">
       <modify-argument index="return">
         <define-ownership owner="python" />


### PR DESCRIPTION
The attributes after-version and before-version restrict the validity of any element to certain Qt versions (after-version means actually including the given version). Additionally there is a new "group" element that only serves the purpose of grouping elements so that the version range doesn't need to repeated. Version strings can be something like "6", "6.5", or "6.5.1".

Some actual elements from the typesystem files have been equipped with these new version attributes for testing purposes.
