### PR TITLE
Make number of classes per generated file configurable

### DIFF
--- a/generator/generatorsetqtscript.cpp
+++ b/generator/generatorsetqtscript.cpp
@@ -55,11 +55,22 @@ QString GeneratorSetQtScript::usage() {
     QString usage =
         "QtScript:\n" 
         "  --nothing-to-report-yet                   \n";
+        "  --max-classes-per-file=<n>                \n";
 
     return usage;
 }
 
 bool GeneratorSetQtScript::readParameters(const QMap<QString, QString> args) {
+    if (args.contains("max-classes-per-file")) {
+        bool ok;
+        int n = args.value("max-classes-per-file").toInt(&ok);
+        if (ok && n > 0) {
+            maxClassesPerFile = n;
+        }
+        else {
+          printf("Invalid value for option --max-classes-per-file (must be number > 0)\n");
+        }
+    }
     return GeneratorSet::readParameters(args);
 }
 
@@ -78,10 +89,10 @@ QString GeneratorSetQtScript::generate() {
     AbstractMetaClassList classes = builder.classesTopologicalSorted();
     QSet<QString> declaredTypeNames = builder.qtMetaTypeDeclaredTypeNames();
 
-    PriGenerator priGenerator;
+    PriGenerator priGenerator(maxClassesPerFile);
     priGenerator.setOutputDirectory(outDir);
 
-    SetupGenerator setupGenerator;
+    SetupGenerator setupGenerator(maxClassesPerFile);
     setupGenerator.setOutputDirectory(outDir);
     setupGenerator.setQtMetaTypeDeclaredTypeNames(declaredTypeNames);
     setupGenerator.setClasses(classes);
@@ -102,10 +113,10 @@ QString GeneratorSetQtScript::generate() {
 
     return QString("Classes in typesystem: %1\n"
                    "Generated:\n"
-                   "  - header....: %4 (%5)\n"
-                   "  - impl......: %6 (%7)\n"
-                   "  - modules...: %8 (%9)\n"
-                   "  - pri.......: %10 (%11)\n"
+                   "  - header....: %2 (%3)\n"
+                   "  - impl......: %4 (%5)\n"
+                   "  - modules...: %6 (%7)\n"
+                   "  - pri.......: %8 (%9)\n"
                    )
         .arg(builder.classes().size())
 

--- a/generator/generatorsetqtscript.h
+++ b/generator/generatorsetqtscript.h
@@ -62,6 +62,7 @@ public:
 
 private:
     MetaQtScriptBuilder builder;
+    int maxClassesPerFile{30};
   
 };
 

--- a/generator/prigenerator.cpp
+++ b/generator/prigenerator.cpp
@@ -93,7 +93,7 @@ static QString combineIncludes(const QString& text) {
   return result;
 }
 
-static QStringList compactFiles(const QStringList& list, const QString& ext, const QString& dir, const QString& prefix) {
+QStringList PriGenerator::compactFiles(const QStringList& list, const QString& ext, const QString& dir, const QString& prefix) {
   QStringList outList;
   int count = list.count();
   int fileNum = 0;
@@ -110,7 +110,7 @@ static QStringList compactFiles(const QStringList& list, const QString& ext, con
     outList << outFileName;
     QString allText;
     QTextStream ts(&allText);
-    for (int i = 0; i<MAX_CLASSES_PER_FILE && count>0; i++) {
+    for (int i = 0; i< maxClassesPerFile && count>0; i++) {
       collectAndRemoveFile(ts,  srcDir + "/" + list.at(list.count()-count));
       count--;
     }

--- a/generator/prigenerator.h
+++ b/generator/prigenerator.h
@@ -58,13 +58,17 @@ class PriGenerator : public Generator
     Q_OBJECT
 
  public:
+    PriGenerator(int classesPerFile) : maxClassesPerFile(classesPerFile) {}
     virtual void generate();
 
     void addHeader(const QString &folder, const QString &header);
     void addSource(const QString &folder, const QString &source);
 
  private:
+    QStringList compactFiles(const QStringList& list, const QString& ext, const QString& dir, const QString& prefix);
+
     QHash<QString, Pri> priHash;
+    int maxClassesPerFile;
 
 };
 #endif // PRIGENERATOR_H

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -285,7 +285,7 @@ void SetupGenerator::generate()
       s << "#include <PythonQt.h>" << endl;
       s << "#include <PythonQtConversion.h>" << endl;
 
-      for (int i=0; i<(list.count()+MAX_CLASSES_PER_FILE-1) / MAX_CLASSES_PER_FILE; i++) {
+      for (int i=0; i<(list.count()+ maxClassesPerFile -1) / maxClassesPerFile; i++) {
         s << "#include \"" << packKey << QString::number(i) << ".h\"" << endl;
       }
       s << endl;

--- a/generator/setupgenerator.h
+++ b/generator/setupgenerator.h
@@ -50,19 +50,23 @@ class SetupGenerator : public Generator
     Q_OBJECT
 
  public:
-    virtual void generate();
+   SetupGenerator(int classesPerFile) : maxClassesPerFile(classesPerFile) {}
 
-    void addClass(const QString& package, const AbstractMetaClass *cls);
+   virtual void generate();
 
-  static void writeInclude(QTextStream &stream, const Include &inc);
+   void addClass(const QString& package, const AbstractMetaClass *cls);
+
+   static void writeInclude(QTextStream &stream, const Include &inc);
   
-  static bool isSpecialStreamingOperator(const AbstractMetaFunction *fun);
+   static bool isSpecialStreamingOperator(const AbstractMetaFunction *fun);
   
  private:
    QStringList writePolymorphicHandler(QTextStream &s, const QString &package,
      const AbstractMetaClassList &polyBaseClasses, QList<const AbstractMetaClass*>& allClasses);
 
    QHash<QString, QList<const AbstractMetaClass*> > packHash;
+
+   int maxClassesPerFile;
 };
 #endif // SETUPGENERATOR_H
 

--- a/generator/shellgenerator.h
+++ b/generator/shellgenerator.h
@@ -46,8 +46,6 @@
 #include "metaqtscript.h"
 #include "prigenerator.h"
 
-#define MAX_CLASSES_PER_FILE 30
-
 class ShellGenerator : public Generator
 {
     Q_OBJECT


### PR DESCRIPTION
This introduces the --max-classes-per-file command line argument. The default for this is 30, as before.

The motivation for this is that comparing the output for different versions (of Qt or the generator) gets easier when everything is one file, so that added or removed classes don't change the output of subsequent files. For this purpose one can use `--max-classes-per-file=10000`.