### PR TITLE
Add Dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly


### PR DESCRIPTION
To automatically update sub-actions like `checkout` or `aqtinstall`, etc.
It is very useful for maintenance to get updates for actions automatically, this happens very rare.
The first proposed PR with `checkout@v4` will break the CI on Centos7. But this issue should be resolved by reverting manually the single line of code just in the branch of PR. Later Dependabot will try again to send the update for this line, but after closing the PR with `@dependabot close` no more annoying attempts to update from `checkout@v3` to `checkout@v4` in any `*.yml` are expected, until the next version `v5` is out.