### PR TITLE
Fix workflow for MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
         cd generator
         # workaround to allow to find the Qt include dirs for installed standard qt packages
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
-        QTDIR=-UNDEFINED- ./pythonqt_generator --include-paths=$Qt5_Dir/lib
+        QTDIR=-UNDEFINED- ./pythonqt_generator --qt-version=${{ steps.versions.outputs.QT_VERSION_FULL }} --include-paths=$Qt5_Dir/lib
 
     - name: Upload Wrappers
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
where the Qt version can't be determined automatically, probably because the include files are inside of frameworks, but that's ok, so we also test giving the version on the command line.

Obviously the merge of the previous merge request was somewhat premature... :)