### PR TITLE
Support QStringView and QAnyStringView as argument and return type

### DIFF
--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
@@ -118,6 +118,12 @@ PythonQtOpengl {
   QT += xml
 }
 
+PythonQtXml {
+  DEFINES += PYTHONQT_WITH_XML
+  Xinclude (com_trolltech_qt_xml)
+  QT += xml
+}
+
 PythonQtXmlpatterns {
   DEFINES += PYTHONQT_WITH_XMLPATTERNS
   Xinclude (com_trolltech_qt_xmlpatterns)

--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
@@ -38,7 +38,7 @@ include ( ../../build/common.prf )
 include ( ../../build/PythonQt.prf )  
 TARGET = $$replace(TARGET, PythonXY, Python$${PYTHON_VERSION})
 
-CONFIG += qt strict_c++
+CONFIG += qt strict_c++ msvc_mp
 
 !static:!staticlib {
   CONFIG += dll

--- a/generator/abstractmetabuilder.h
+++ b/generator/abstractmetabuilder.h
@@ -96,6 +96,10 @@ public:
     void traverseStreamOperator(FunctionModelItem function_item);
     void traverseCompareOperator(FunctionModelItem item);
     void traverseBinaryArithmeticOperator(FunctionModelItem item);
+    
+    //! remove functions/methods that are overloads with equivalent parameter types
+    //! when called from Python
+    void removeEquivalentFunctions(AbstractMetaClass* parent);
 
     AbstractMetaFunction *traverseFunction(FunctionModelItem function);
     AbstractMetaField *traverseField(VariableModelItem field, const AbstractMetaClass *cls);

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -1103,6 +1103,11 @@ void AbstractMetaClass::addFunction(AbstractMetaFunction *function)
     m_has_nonpublic |= !function->isPublic();
 }
 
+void AbstractMetaClass::removeFunction(AbstractMetaFunction* function)
+{
+  m_functions.removeOne(function);
+}
+
 bool AbstractMetaClass::hasSignal(const AbstractMetaFunction *other) const
 {
     if (!other->isSignal())

--- a/generator/abstractmetalang.h
+++ b/generator/abstractmetalang.h
@@ -688,6 +688,7 @@ public:
     AbstractMetaFunctionList functions() const { return m_functions; }
     void setFunctions(const AbstractMetaFunctionList &functions);
     void addFunction(AbstractMetaFunction *function);
+    void removeFunction(AbstractMetaFunction* function);
     bool hasFunction(const AbstractMetaFunction *f) const;
     bool hasFunction(const QString &str) const;
     bool hasSignal(const AbstractMetaFunction *f) const;

--- a/generator/generator.pri
+++ b/generator/generator.pri
@@ -5,6 +5,7 @@ TEMPLATE = app
 #CONFIG += cmdline -- does not work as expected with old Qt versions, f.e. is missing in 5.9
 CONFIG += console
 CONFIG -= app_bundle
+CONFIG += msvc_mp
 
 TARGET +=
 DEPENDPATH += $$GENERATORPATH tests parser

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1509,22 +1509,27 @@ TypeDatabase *TypeDatabase::instance()
 
 TypeDatabase::TypeDatabase() : m_suppressWarnings(true)
 {
-    addType(new StringTypeEntry("QString"));
+    StringTypeEntry* mainStringType = new StringTypeEntry("QString");
+    addType(mainStringType);
 
     StringTypeEntry *e = new StringTypeEntry("QLatin1String");
     e->setPreferredConversion(false);
+    e->setEquivalentType(mainStringType);
     addType(e);
 
     e = new StringTypeEntry("QStringRef");
     e->setPreferredConversion(false);
+    e->setEquivalentType(mainStringType);
     addType(e);
 
     e = new StringTypeEntry("QStringView");
     e->setPreferredConversion(false);
+    e->setEquivalentType(mainStringType);
     addType(e);
 
     e = new StringTypeEntry("QAnyStringView");
     e->setPreferredConversion(false);
+    e->setEquivalentType(mainStringType);
     addType(e);
 
     e = new StringTypeEntry("QXmlStreamStringRef");

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1519,6 +1519,14 @@ TypeDatabase::TypeDatabase() : m_suppressWarnings(true)
     e->setPreferredConversion(false);
     addType(e);
 
+    e = new StringTypeEntry("QStringView");
+    e->setPreferredConversion(false);
+    addType(e);
+
+    e = new StringTypeEntry("QAnyStringView");
+    e->setPreferredConversion(false);
+    addType(e);
+
     e = new StringTypeEntry("QXmlStreamStringRef");
     e->setPreferredConversion(false);
     addType(e);

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -549,6 +549,8 @@ public:
 
     virtual bool isNativeIdBased() const { return false; }
 
+    virtual TypeEntry* equivalentType() const { return nullptr; }
+
 private:
     QString m_name;
     Type m_type;
@@ -1013,8 +1015,14 @@ public:
 
     virtual bool isNativeIdBased() const { return true; }
 
+    virtual TypeEntry* equivalentType() const { return _equivalentType; }
+    void setEquivalentType(TypeEntry* typeEntry) { _equivalentType = typeEntry; }
+
 protected:
     ValueTypeEntry(const QString &name, Type t) : ComplexTypeEntry(name, t) { }
+
+private:
+  TypeEntry* _equivalentType{};
 };
 
 

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -122,10 +122,7 @@ void PythonQt::init(int flags, const QByteArray& pythonQtModuleName)
     } else {
       qRegisterMetaType<quint32>("size_t");
     }
-#if QT_VERSION < 0x060000
-    int stringRefId = qRegisterMetaType<QStringRef>("QStringRef");
-    PythonQtConv::registerMetaTypeToPythonConverter(stringRefId, PythonQtConv::convertFromStringRef);
-#endif
+    PythonQtConv::registerStringViewTypes();
 
     int objectPtrListId = qRegisterMetaType<QList<PythonQtObjectPtr> >("QList<PythonQtObjectPtr>");
     PythonQtConv::registerMetaTypeToPythonConverter(objectPtrListId, PythonQtConv::convertFromQListOfPythonQtObjectPtr);

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -187,6 +187,9 @@ public:
   static PyObject* convertFromQListOfPythonQtObjectPtr(const void* /* QList<PythonQtObjectPtr>* */ inObject, int /*metaTypeId*/);
 #if QT_VERSION < 0x060000
   static PyObject* convertFromStringRef(const void* inObject, int /*metaTypeId*/);
+#else
+  static PyObject* convertFromStringView(const void* inObject, int /*metaTypeId*/);
+  static PyObject* convertFromAnyStringView(const void* inObject, int /*metaTypeId*/);
 #endif
 
   //! Returns the name of the equivalent CPP type (for signals and slots)
@@ -194,6 +197,9 @@ public:
 
   //! Returns if the given object is a string (or unicode string)
   static bool isStringType(PyTypeObject* type);
+
+  //! Register QStringView like types, that need to be handled specially
+  static void registerStringViewTypes();
 
 protected:
   static QHash<int, PythonQtConvertMetaTypeToPythonCB*> _metaTypeToPythonConverters;
@@ -215,6 +221,12 @@ protected:
   template <typename Map>
   static PyObject* mapToPython (const Map& m);
 
+#if QT_VERSION < 0x060000
+  static int stringRefTypeId;
+#else
+  static int stringViewTypeId;
+  static int anyStringViewTypeId;
+#endif
 };
 
 template<class ListType, class T>

--- a/src/src.pro
+++ b/src/src.pro
@@ -9,7 +9,7 @@ TEMPLATE = lib
 
 DESTDIR    = ../lib
 
-CONFIG += qt
+CONFIG += qt msvc_mp
 CONFIG -= flat
 
 # allow to choose static linking through the environment variable PYTHONQT_STATIC


### PR DESCRIPTION
QStringView and QAnyStringView are interfaces to treat different string origins the same. In Qt5 we had QStringRef instead.

To support this as an argument from Python, we also need to (temporarily) store the original QString somewhere, and then create the Q(Any)StringView from it. The old code supported QStringRef as return value, but didn't allow it as argument type, as far as I can see. But the code supports QString* as argument type, which is a somewhat similar case. I took my inspiration how to handle the view classes from that.

After fixing this it became apparent that in C++ there often were several overloads of a method that amounted to basically the same call interface in Python (QString, QLatin1String, QStringView). So I wrote code to remove superfluous overloads.

This is untested yet, I asked mrbean-bremen for that, since he is currently working with this code.