### PR TITLE
Add "enum class" values to the enum type in Python

### DIFF
--- a/src/PythonQtClassInfo.h
+++ b/src/PythonQtClassInfo.h
@@ -237,6 +237,10 @@ public:
   //! _typeSlots with Type_RichCompare. The result is cached internally.
   bool supportsRichCompare();
 
+  //! Sometimes enum values use a reserved name in Python. In this case
+  //! replace it with something that is not reserved
+  QByteArray escapeReservedNames(const QByteArray& name);
+
 private:
   void updateRefCountingCBs();
 
@@ -300,6 +304,7 @@ private:
   bool _searchPolymorphicHandlerOnParent;
   bool _searchRefCountCB;
 
+  static QSet<QByteArray> _reservedNames;
 };
 
 //---------------------------------------------------------------


### PR DESCRIPTION
Enum class values seem to have pretty generic names (as there is no danger
of name clashes in C++, as they must always be prefixed with the enum
class name). So add them to the enum type in Python too, so one can
always write something like QActionGroup.ExclusionPolicy.None instead of
QActionGroup.None.

Ideally we wouldn't add the enum values to the parent class at all, but
I don't want to break compatibility with older versions of PythonQt.

Also added code to escape names that are reserved in Python.