### PR TITLE
More typesystem entries (added classes and rejections)

### DIFF
--- a/generator/typesystem_core.xml
+++ b/generator/typesystem_core.xml
@@ -19,21 +19,38 @@
 <rejection class="QAbstractNativeEventFilter"/>
 <rejection class="QAbstractOpenGLFunctions"/>
 <rejection class="QAbstractOpenGLFunctionsPrivate"/>
+<rejection class="QAdoptSharedDataTag"/>
 <rejection class="QAnimationDriver"/>
 <rejection class="QArrayData"/>
 <rejection class="QArrayDataOps"/>
 <rejection class="QArrayDataPointer"/>
 <rejection class="QArrayDataPointerRef"/>
 <rejection class="QArrayOpsSelector"/>
+<rejection class="QAssociativeConstIterator"/>
 <rejection class="QAssociativeIterable"/>
 <rejection class="QAtomicAdditiveType"/>
 <rejection class="QAtomicInteger"/>
 <rejection class="QAtomicOps"/>
+<rejection class="QAtomicOpsSupport"/>
 <rejection class="QAtomicOpsSupport>"/>
+<rejection class="QAtomicTraits"/>
+<rejection class="QBaseIterator"/>
 <rejection class="QBasicAtomicInteger"/>
+<rejection class="QBasicUtf8StringView"/>
+<rejection class="QBigEndianStorageType"/>
+<rejection class="QBindable"/>
+<rejection class="QBindingStatus"/>
+<rejection class="QBindingStorage"/>
 <rejection class="QByteArrayDataPtr"/>
+<rejection class="QConstIterator"/>
+<rejection class="QConstOverload"/>
+<rejection class="QDateTime::Data"/>
+<rejection class="QDateTime::ShortData"/>
 <rejection class="QDebugStateSaver"/>
 <rejection class="QEnableSharedFromThis"/>
+<rejection class="QEvent::InputEventTag"/>
+<rejection class="QEvent::PointerEventTag"/>
+<rejection class="QEvent::SinglePointEventTag"/>
 <rejection class="QEventLoopLocker"/>
 <rejection class="QException"/>
 <rejection class="QGLFunctionsPrivate"/>
@@ -203,6 +220,8 @@
   <primitive-type name="qintptr"/>
   <primitive-type name="qptrdiff"/>
   <primitive-type name="qsizetype"/>
+  
+  <rejection class="qfloat16"/>  <!-- only used in QRgbaFloat template and QCborStreamReader/Writer so far -->
 
   <value-type name="QModelIndex"/>
   <rejection class="*" function-name="d_func"/>
@@ -220,6 +239,7 @@
   <rejection class="" enum-name="QtValidLicenseForSqlModule"/>
   <rejection class="" enum-name="QtValidLicenseForOpenGLModule"/>
   <rejection class="" enum-name="enum_1"/>
+  <rejection class="" enum-name="enum_2"/>
   <rejection class="" enum-name="QtValidLicenseForXmlModule"/>
   <rejection class="" enum-name="QtValidLicenseForXmlPatternsModule"/>
   <rejection class="" enum-name="QtValidLicenseForActiveQtModule"/>
@@ -241,6 +261,7 @@
   <rejection class="QtConcurrent" function-name="operator|"/>
 
   <rejection class="Qt" enum-name="Modifier"/>
+  <rejection class="Qt" enum-name="ReturnByValueConstant"/>
   <rejection class="Qt" function-name="qt_getEnumName"/>
   <rejection class="Qt" function-name="qt_getEnumMetaObject"/>
 
@@ -416,6 +437,8 @@
 
   <rejection class="QBitRef"/>
   <rejection class="QCache"/>
+  <rejection class="QCalendar::SystemId"/>   <!-- not clear how to get this -->
+  <rejection class="QCalendar" enum-name="enum_1"/>   <!-- not clear how to get this -->
   <rejection class="QContiguousCache"/>
   <rejection class="QContiguousCacheData"/>
   <rejection class="QContiguousCacheTypedData"/>
@@ -444,43 +467,112 @@
   <rejection class="QHashNode"/>
   <rejection class="QInternal"/>
   <rejection class="QIncompatibleFlag"/>
+  <rejection class="QIterable"/>
+  <rejection class="QIterator"/>
+  <rejection class="QJSListIndexClamp"/>
+  <rejection class="QJSNumberCoercion"/>
+  <rejection class="QJsonValueConstRef"/>
+  <rejection class="QKeyValueIterator"/>
+  <rejection class="QLatin1StringMatcher"/>
   <rejection class="QLinkedList"/>
   <rejection class="QLinkedListData"/>
   <rejection class="QLinkedListIterator"/>
   <rejection class="QLinkedListNode"/>
+  <rejection class="QList::DisableRValueRefs"/>
   <rejection class="QListData"/>
   <rejection class="QListIterator"/>
+  <rejection class="QListSpecialMethodsBase"/>
+  <rejection class="QLittleEndianStorageType"/>
+  <rejection class="QLoggingCategoryMacroHolder"/>
   <rejection class="QMap"/>
   <rejection class="QMapNode"/>
   <rejection class="QMapPayloadNode"/>
   <rejection class="QMapData"/>
   <rejection class="QMapIterator"/>
   <rejection class="QMetaTypeId"/>
+  <rejection class="QMetaAssociation"/>
+  <rejection class="QMetaClassInfo::Data"/>
+  <rejection class="QMetaContainer"/>
+  <rejection class="QMetaEnum::Data"/>
+  <rejection class="QMetaMethod::Data"/>
+  <rejection class="QMetaProperty::Data"/>
+  <rejection class="QMetaSequence"/>
   <rejection class="QMultiHash"/>
+  <rejection class="QMultiHashIterator"/>
   <rejection class="QMultiMap"/>
+  <rejection class="QMultiMapIterator"/>
   <rejection class="QMutableHashIterator"/>
   <rejection class="QMutableLinkedListIterator"/>
   <rejection class="QMutableListIterator"/>
   <rejection class="QMutableMapIterator"/>
+  <rejection class="QMutableMultiHashIterator"/>
+  <rejection class="QMutableMultiMapIterator"/>
   <rejection class="QMutableVectorIterator"/>
   <rejection class="QNoImplicitBoolCast"/>
+  <rejection class="QNonConstOverload"/>
+  <rejection class="QObjectBindableProperty"/>
+  <rejection class="QObjectComputedProperty"/>
   <rejection class="QObjectCleanupHandler"/>
   <rejection class="QObjectData"/>
   <rejection class="QObjectUserData"/>
+  <rejection class="QOverload"/>
+  <rejection class="QPartialOrdering"/>  <!-- used for QVariant and QMetaType, not usable from Python -->
   <rejection class="QPluginLoader"/>
+  <rejection class="QPluginMetaData"/>
   <rejection class="QPointer"/>
+  <rejection class="QProperty"/>
+  <rejection class="QPropertyAlias"/>
+  <rejection class="QPropertyBinding"/>
+  <rejection class="QPropertyBindingError"/>
+  <rejection class="QPropertyBindingPrivatePtr"/>
+  <rejection class="QPropertyBindingSourceLocation"/>
+  <rejection class="QPropertyData"/>
+  <rejection class="QPropertyObserver"/>
+  <rejection class="QPropertyObserverBase"/>
+  <rejection class="QPropertyProxyBindingData"/>
+  <rejection class="QRandomGenerator::InitialRandomData"/>
+  <rejection class="QRandomGenerator::Storage"/>
+  <rejection class="QRandomGenerator" enum-name="System"/>
+  <rejection class="QRgbaFloat"/>  <!-- template class -->
+  <rejection class="QScopeGuard"/>
+  <rejection class="QScopedPropertyUpdateGroup"/>  <!-- wouldn't work the same in Python -->
+  <rejection class="QSemaphoreReleaser"/>  <!-- wouldn't work the same in Python -->
+  <rejection class="QSequentialConstIterator"/>
+  <rejection class="QSequentialIterator"/>
   <rejection class="QSet"/>
   <rejection class="QSetIterator"/>
   <rejection class="QSharedData"/>
   <rejection class="QSharedDataPointer"/>
+  <rejection class="QSpecialInteger"/>
+  <rejection class="QSocketDescriptor"/>  <!-- might be needed in future, emitted by QSocketNotifier::activated -->
   <rejection class="QStack"/>
+  <rejection class="QStaticByteArrayMatcher"/>
+  <rejection class="QStaticByteArrayMatcherBase"/>
+  <!-- QStringConvert & co. use templates for return values -->
+  <rejection class="QStringConverter"/>
+  <rejection class="QStringConverterBase"/>
+  <rejection class="QStringEncoder"/>
+  <rejection class="QStringDecoder"/>
+  <rejection class="QStringTokenizer"/>
+  <rejection class="QStringTokenizerBase"/>
+  <rejection class="QStringTokenizerBaseBase"/>
+  <rejection class="QTaggedIterator"/>
+  <rejection class="QTaggedPointer"/>
   <rejection class="QTextStreamManipulator"/>
   <rejection class="QThreadStorage"/>
   <rejection class="QThreadStorageData"/>
+  <rejection class="QTimeZone::Data"/>
+  <rejection class="QTimeZone::ShortData"/>
   <rejection class="QTypeInfo"/>
-  <rejection class="QTypeInfo"/>
+  <rejection class="QTypeRevision"/>   <!-- type not usable (static creator methods are templated) -->
+  <rejection class="QUntypedBindable"/>
+  <rejection class="QUntypedPropertyBinding"/>
+  <rejection class="QUntypedPropertyData"/>
   <rejection class="QVFbKeyData"/>
   <rejection class="QVariantComparisonHelper"/>
+  <rejection class="QVariantConstPointer"/>
+  <rejection class="QVariantPointer"/>
+  <rejection class="QVariantRef"/>
   <rejection class="QVectorData"/>
   <rejection class="QVectorIterator"/>
   <rejection class="QVectorTypedData"/>
@@ -513,6 +605,9 @@
   <rejection class="QLocale::Data"/>
   <rejection class="QGlobalStaticDeleter"/>
   <rejection class="QVarLengthArray"/>
+  <rejection class="QVLABase"/>
+  <rejection class="QVLABaseBase"/>
+  <rejection class="QVLAStorage"/>
 
   <!-- DBus -->
   <rejection class="QDBusAbstractAdaptor"/>
@@ -531,6 +626,20 @@
   <rejection class="QDBusSignature"/>
   <rejection class="QDBusVariant"/>
 
+  <!-- QPermission (templated) -->
+  <rejection class="QPermission"/>
+  <rejection class="QBluetoothPermission"/>
+  <rejection class="QCalendarPermission"/>
+  <rejection class="QCameraPermission"/>
+  <rejection class="QContactsPermission"/>
+  <rejection class="QLocationPermission"/>
+  <rejection class="QMicrophonePermission"/>
+  <rejection class="Qt" enum-name="PermissionStatus"/>
+
+  <!-- Template parameters in QSGTexture: -->
+  <rejection class="NativeInterface"/>
+  <rejection class="TypeInfo"/>
+
   <rejection class="_Revbidit"/>
   <rejection class="_complex"/>
   <rejection class="_exception"/>
@@ -544,8 +653,11 @@
   <rejection class="reverse_iterator"/>
   <rejection class="stat"/>
   <rejection class="tm"/>
+  <rejection class="function_ref"/>
+  <rejection class="has_type_info"/>
 
   <rejection class="Qt" enum-name="Initialization"/>
+  <rejection class="Qt::Disambiguated_t"/>
 
   <rejection class="QAbstractEventDispatcher" function-name="filterEvent"/>
   <rejection class="QAbstractEventDispatcher" function-name="setEventFilter"/>
@@ -968,6 +1080,7 @@ public:
       <remove/>
     </modify-function>
   </value-type>
+  <rejection class="QUuid::Id128Bytes" since-version="6.6"/>
 
   <value-type name="QLocale">
     <modify-function signature="toString(unsigned long long) const" remove="all"/>
@@ -989,6 +1102,8 @@ public:
     <modify-function signature="operator[](int)const" remove="all"/>
     <modify-function signature="operator[](uint)const" remove="all"/>
     <modify-function signature="operator[](uint)" remove="all"/>
+    <modify-function signature="operator[](qsizetype)" remove="all"/>
+    <modify-function signature="operator[](qsizetype)const" remove="all"/>
 
     <modify-function signature="operator&amp;=(QBitArray)" access="private"/>
     <modify-function signature="operator=(QBitArray)" access="private"/>
@@ -1104,6 +1219,7 @@ public:
     <modify-function signature="operator[](uint)" remove="all"/>
     <modify-function signature="operator[](uint)const" remove="all"/>
     <modify-function signature="operator[](qsizetype)" remove="all"/>
+    <modify-function signature="operator[](qsizetype)const" remove="all"/>
     <modify-function signature="push_back(char)" remove="all"/>
     <modify-function signature="push_back(const char*)" remove="all"/>
     <modify-function signature="push_front(char)" remove="all"/>
@@ -1220,6 +1336,7 @@ public:
     <modify-function signature="fromRawData(const char*,qsizetype)" remove="all"/>
   </value-type>
   <rejection class="QByteArray" function-name="erase"/>
+  <value-type name="QByteArray::FromBase64Result" since-version="5.15"/>
 
   <value-type name="QTextBoundaryFinder">
     <modify-function signature="QTextBoundaryFinder(QTextBoundaryFinder::BoundaryType,const QChar*,int,unsigned char*,int)" remove="all"/>
@@ -1345,7 +1462,6 @@ public:
   <object-type name="QLibraryInfo"/>
   <object-type name="QMutex"/>
   <object-type name="QRecursiveMutex" since-version="5.14"/>
-  <!-- QMutexLocker is a template in Qt6, we need to figure out what to do with it... -->
   <value-type name="QMutexLocker" before-version="6">
     <!-- special handling for context handlers -->
     <inject-code class="pywrap-operators">PythonQt::Type_EnterExit</inject-code>
@@ -1354,6 +1470,8 @@ public:
     void __exit__(QMutexLocker* self, PyObject* /*type*/, PyObject* /*value*/, PyObject* /*traceback*/) { self->unlock(); }
     </inject-code>
   </value-type>
+  <!-- QMutexLocker is a template in Qt6, we need to figure out what to do with it... -->
+  <rejection class="QMutexLocker" since-version="6"/>
   <value-type name="QReadLocker">
     <!-- special handling for context handlers -->
     <inject-code class="pywrap-operators">PythonQt::Type_EnterExit</inject-code>
@@ -1436,6 +1554,7 @@ public:
     <modify-function signature="disconnectNotify(const char *)" remove="all"/>
 
     <modify-function signature="setData(const char*,int)" remove="all"/>
+    <modify-function signature="setData(const char*,qsizetype)" remove="all"/>
   </object-type>
 
   <object-type name="QTimer"/>
@@ -1464,6 +1583,9 @@ public:
   <enum-type name="QProcess::UnixProcessFlag" flags="QProcess::UnixProcessFlags" since-version="6.6"/>
   <value-type name="QProcess::UnixProcessParameters" since-version="6.6"/>
   -->
+  <rejection class="QProcess" enum-name="UnixProcessFlag" since-version="6.6"/>
+  <rejection class="QProcess::UnixProcessParameters" since-version="6.6"/>
+  <rejection class="QProcess::Use_setChildProcessModifier_Instead" since-version="6.6"/>
 
   <object-type name="QSignalMapper">
   </object-type>
@@ -1839,6 +1961,9 @@ public:
   <object-type name="QResource"/>
   <enum-type name="QResource::Compression"/>
   <object-type name="QSharedMemory"/>
+  <object-type name="QNativeIpcKey" since-version="6.6"/>
+  <enum-type name="QNativeIpcKey::Type" since-version="6.6"/>
+  <rejection class="QNativeIpcKey::TypeAndFlags" since-version="6.6"/>
   <object-type name="QMetaObject"/>
   <object-type name="QMetaMethod"/>
   <object-type name="QMetaEnum">
@@ -1857,6 +1982,83 @@ public:
     <modify-function signature="registerConverter()" remove="all"/>
     <modify-function signature="registerDebugStreamOperator()" remove="all"/>
   </object-type>
+
+  <!-- Don't know if QCborNegativeInteger can be sensibly supported in Python: -->
+  <rejection enum-name="QCborNegativeInteger" since-version="5.12"/>
+  
+  <object-type name="QCborStreamWriter" since-version="5.12">
+    <modify-function signature="append(QCborTag)" remove="all"/> 
+    <modify-function signature="append(const char*,qsizetype)" remove="all"/> 
+    <modify-function signature="QCborStreamWriter(const QCborStreamWriter&amp;)" remove="all"/> 
+    <modify-function signature="operator=(const QCborStreamWriter&amp;)" remove="all"/> 
+  </object-type>
+  <object-type name="QCborStreamReader" since-version="5.12">
+    <modify-function signature="readByteArray()" remove="all"/> 
+    <modify-function signature="readString()" remove="all"/> 
+    <modify-function signature="readStringChunk(char*,qsizetype)" remove="all"/> 
+    <modify-function signature="toTag()const" remove="all"/> 
+    <modify-function signature="QCborStreamReader(const QCborStreamReader&amp;)" remove="all"/> 
+    <modify-function signature="operator=(const QCborStreamReader&amp;)" remove="all"/> 
+    <inject-code class="pywrap-h">
+  QByteArray readByteArray(QCborStreamReader* theWrappedObject) {
+    auto result = theWrappedObject->readByteArray();
+    return result.status == QCborStreamReader::Ok ? result.data : QByteArray();
+  }
+    
+  QString readString(QCborStreamReader* theWrappedObject) {
+    auto result = theWrappedObject->readString();
+    return result.status == QCborStreamReader::Ok ? result.data : QString();
+  }
+    
+  qint64 toTag(QCborStreamReader* theWrappedObject) const {
+    return static_cast&lt;qint64&gt;(theWrappedObject->toTag());
+  }
+    </inject-code>
+  </object-type>
+  <object-type name="QCborValue" since-version="5.12">
+    <modify-function signature="QCborValue(QCborTag, const QCborValue&amp;)" remove="all"/>
+    <modify-function signature="tag(QCborTag)const" remove="all"/>
+    <inject-code class="pywrap-h">
+  // replace QCborTag with qint64:
+  QCborValue* new_QCborValue(qint64  tag, const QCborValue&amp; taggedValue) {
+    return new QCborValue(QCborTag(tag), taggedValue);
+  }
+  
+  qint64 tag(QCborValue* theWrappedObject, qint64 defaultValue) const {
+    return static_cast&lt;qint64&gt;(theWrappedObject->tag(QCborTag(defaultValue)));
+  }
+    </inject-code>
+  </object-type>
+  <enum-type name="QCborValue::DiagnosticNotationOption" flags="QCborValue::DiagnosticNotationOptions" since-version="5.12"/>
+  <enum-type name="QCborValue::EncodingOption" flags="QCborValue::EncodingOptions" since-version="5.12"/>
+  <enum-type name="QCborValue::Type" since-version="5.12"/>
+  <object-type name="QCborArray" since-version="5.12">
+  </object-type>
+  <rejection class="QCborArray::Iterator"/>
+  <rejection class="QCborArray::ConstIterator"/>
+  <object-type name="QCborMap" since-version="5.12">
+    <inject-code class="pywrap-h">
+  void insert(QCborMap* theWrappedObject, qint64 key, const QCborValue&amp; value_)
+  {
+    theWrappedObject->insert(key, value_);
+  }
+
+  void insert(QCborMap* theWrappedObject, const QString&amp; key, const QCborValue&amp; value_)
+  {
+    theWrappedObject->insert(key, value_);
+  }
+    </inject-code>
+  </object-type>
+  <rejection class="QCborMap::Iterator"/>
+  <rejection class="QCborMap::ConstIterator"/>
+  <object-type name="QCborError" since-version="5.12">
+    <modify-function signature="operator Code()const" remove="all"/>
+  </object-type>
+  <enum-type name="QCborError::Code" since-version="5.12"/>
+  <object-type name="QCborParserError" since-version="5.12"/>
+  <rejection class="QCborValueRef" since-version="5.12"/>
+  <rejection class="QCborValueConstRef" since-version="5.12"/>
+
 
   <!-- Inefficient hash codes -->
   <suppress-warning text="WARNING(MetaJavaBuilder) :: Class 'QUuid' has equals operators but no qHash() function. Hashcode of objects will consistently be 0."/>
@@ -2075,6 +2277,9 @@ public:
   <object-type name="QRandomGenerator"/>
   <object-type name="QRandomGenerator64"/>
   <enum-type name="QDeadlineTimer::ForeverConstant"/>
+  <object-type name="QHashSeed" since-version="6.2">
+    <modify-function signature="operator size_t()const" remove="all"/>
+  </object-type>
   
   <enum-type name="QCommandLineOption::Flag"/>
   <enum-type name="QFileDevice::FileTime"/>

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -22,11 +22,13 @@
 <rejection class="QAccessible"/>
 <rejection class="QAccessibleActionInterface"/>
 <rejection class="QAccessibleBridge"/>
+<rejection class="QAccessibleHyperlinkInterface"/>
 <rejection class="QAccessibleImageInterface"/>
 <rejection class="QAccessibleInterface"/>
 <rejection class="QAccessibleObject"/>
 <rejection class="QAccessiblePlugin"/>
 <rejection class="QAccessibleStateChangeEvent"/>
+<rejection class="QAccessibleSelectionInterface"/>
 <rejection class="QAccessibleTableCellInterface"/>
 <rejection class="QAccessibleTableInterface"/>
 <rejection class="QAccessibleTableModelChangeEvent"/>
@@ -84,6 +86,7 @@
   <rejection class="QAbstractUndoItem"/>
   <rejection class="QAccessibleApplication"/>
   <rejection class="QBrushData"/>
+  <rejection class="QBrushDataPointerDeleter"/>
   <rejection class="QImageTextKeyLang"/>
   <rejection class="QItemEditorCreator"/>
   <rejection class="QLinkedList"/>
@@ -104,6 +107,7 @@
   <rejection class="QWindowSurface"/>
   <rejection class="QWindowsXPStyle"/>
   <rejection class="QWindowsVistaStyle"/>
+  <rejection class="QWindowsMimeConverter"/>
   <rejection class="QWSEmbedWidget"/>
   <rejection class="QRegion::QRegionData"/>
   <rejection class="JObject_key"/>
@@ -156,13 +160,15 @@
   <rejection class="QWidgetItem" field-name="wid"/>
   <rejection class="QFont" enum-name="ResolveProperties"/>
   <rejection class="QGradient" enum-name="InterpolationMode"/>
+  <rejection class="QIconEngine::ScaledPixmapArgument" since-version="5.9"/>
   <rejection class="QIconEngineV2::AvailableSizesArgument"/>
   <rejection class="QIconEngineV2" enum-name="IconEngineHook"/>
+  <rejection class="QGradient::QGradientData"/>
   <rejection class="QGradient" enum-name="InterpolationMode"/>
   <rejection class="QGradient" function-name="setInterpolationMode"/>
   <rejection class="QGradient" function-name="interpolationMode"/>
   <rejection class="QAbstractTextDocumentLayout" function-name="handlerForObject"/>
-    <rejection class="QPixmap" function-name="fromImageInPlace"/>
+  <rejection class="QPixmap" function-name="fromImageInPlace"/>
   
   <enum-type name="QStaticText::PerformanceHint"/>
   <enum-type name="QTextBlockFormat::LineHeightTypes"/>
@@ -390,6 +396,8 @@
   <enum-type name="QStyleOptionHeader::SortIndicator"/>
   <enum-type name="QStyleOptionHeader::StyleOptionType"/>
   <enum-type name="QStyleOptionHeader::StyleOptionVersion"/>
+  <enum-type name="QStyleOptionHeaderV2::StyleOptionType"/>
+  <enum-type name="QStyleOptionHeaderV2::StyleOptionVersion"/>
   <enum-type name="QStyleOptionMenuItem::CheckType"/>
   <enum-type name="QStyleOptionMenuItem::MenuItemType"/>
   <enum-type name="QStyleOptionMenuItem::StyleOptionType"/>
@@ -615,6 +623,7 @@
         </modify-argument>
       </modify-function>
   </value-type>
+  <rejection class="QTransform::Affine"/>
 
   <value-type name="QStyleOption" polymorphic-base="yes" polymorphic-id-expression="%1-&gt;type == QStyleOption::SO_Default">
       <modify-function signature="operator=(QStyleOption)" remove="all"/>
@@ -641,6 +650,7 @@
 
   <value-type name="QStyleOptionGroupBox" polymorphic-id-expression="%1-&gt;type == QStyleOptionGroupBox::Type &amp;&amp; %1-&gt;version == QStyleOptionGroupBox::Version"/>
   <value-type name="QStyleOptionHeader" polymorphic-id-expression="%1-&gt;type == QStyleOptionHeader::Type &amp;&amp; %1-&gt;version == QStyleOptionHeader::Version"/>
+  <value-type name="QStyleOptionHeaderV2" polymorphic-id-expression="%1-&gt;type == QStyleOptionHeaderV2::Type &amp;&amp; %1-&gt;version == QStyleOptionHeaderV2::Version"/>
   <value-type name="QStyleOptionMenuItem" polymorphic-id-expression="%1-&gt;type == QStyleOptionMenuItem::Type &amp;&amp; %1-&gt;version == QStyleOptionMenuItem::Version"/>
   <value-type name="QStyleOptionProgressBar" polymorphic-id-expression="%1-&gt;type == QStyleOptionProgressBar::Type &amp;&amp; %1-&gt;version == QStyleOptionProgressBar::Version"/>
 
@@ -892,6 +902,7 @@
     <modify-function signature="data()const" remove="all"/>
     <modify-function signature="operator()(int, int)const" remove="all"/>
   </value-type>
+  <rejection class="QMatrix4x4" enum-name="Flag"/>
   <value-type name="QMatrix">
       <extra-includes>
         <include file-name="QPainterPath" location="global"/>
@@ -1120,6 +1131,7 @@ PyObject* constScanLine(QImage* image, int line) {
       <modify-function signature="dark(int)const" remove="all"/> <!--### Obsolete in 4.3-->
       <modify-function signature="light(int)const" remove="all"/> <!--### Obsolete in 4.3-->
   </value-type>
+  <rejection class="QColor::CT"/>
 
   <value-type name="QFontMetricsF" expense-cost="1" expense-limit="1000">
     <modify-function signature="operator!=(const QFontMetricsF &amp;)">
@@ -1326,6 +1338,7 @@ PyObject* constScanLine(QImage* image, int line) {
   <object-type name="QHeaderView">
   </object-type>
   <object-type name="QIconEngine">
+    <modify-function signature="virtual_hook(int,void*)" remove="all"/>
   </object-type>
   <object-type name="QIconEngineV2">
     <modify-function signature="virtual_hook(int,void*)" remove="all"/>
@@ -2936,6 +2949,7 @@ PyObject* constScanLine(QImage* image, int line) {
       </modify-argument>
     </modify-function>
   </object-type>
+  <value-type name="QFormLayout::TakeRowResult" since-version="5.8"/>
     
   <object-type name="QGraphicsGridLayout">
     <modify-function signature="addItem(QGraphicsLayoutItem*,int,int,QFlags&lt;Qt::AlignmentFlag&gt;)">
@@ -3078,6 +3092,7 @@ PyObject* constScanLine(QImage* image, int line) {
   <object-type name="QOpenGLTimeMonitor"/>
   <object-type name="QOpenGLTimerQuery"/>
   <object-type name="QOpenGLVersionProfile"/>
+  <object-type name="QOpenGLVersionFunctionsFactory" since-version="6"/>
   <object-type name="QOpenGLVertexArrayObject"/>
   <object-type name="QPageLayout"/>
   <object-type name="QPageSize"/>
@@ -3096,7 +3111,8 @@ PyObject* constScanLine(QImage* image, int line) {
   <interface-type name="QPagedPaintDevice" create-shell="no">
     <modify-function signature="devicePageLayout()const" remove="all"/>
   </interface-type>
-  <interface-type name="QPageRanges"/>
+  <interface-type name="QPageRanges" since-version="6"/>
+  <value-type name="QPageRanges::Range" since-version="6"/>
 
    <interface-type name="QPlatformSurface"/>
    <interface-type name="QSurface"/>
@@ -3180,6 +3196,7 @@ PyObject* constScanLine(QImage* image, int line) {
   <object-type name="QOpenGLTextureBlitter"/>
   <enum-type name="QOpenGLTextureBlitter::Origin"/>
   
+  <object-type name="QConcatenateTablesProxyModel" since-version="5.13"/>
   <object-type name="QTransposeProxyModel" since-version="5.13"/>
 
   <value-type name="QColorSpace" since-version="5.14"/>

--- a/generator/typesystem_multimedia.xml
+++ b/generator/typesystem_multimedia.xml
@@ -7,6 +7,8 @@
 <rejection class="QAudioBuffer::StereoFrame"/>
 <rejection class="QVideoFilterRunnable"/>
 <rejection class="QAbstractVideoFilter"/>
+<rejection class="QAudioFrame"/>   <!-- template class -->
+<rejection class="QWaveDecoder"/>   <!-- not documented, probably should use QAudioDecoder instead -->
 
 <enum-type name="QAudioFormat::Endian"/>
 <enum-type name="QAudioFormat::SampleType"/>
@@ -126,11 +128,14 @@
 <enum-type name="QVideoFrame::HandleType"/>
 <enum-type name="QVideoFrame::MapMode"/>
 <enum-type name="QVideoFrame::RotationAngle"/>
+<object-type name="QVideoFrame::PaintOptions"/>
+<enum-type name="QVideoFrame::PaintOptions::PaintFlag" flags="QVideoFrame::PaintOptions::PaintFlags"/>
 </group>
 <object-type name="QVideoProbe"/>
 <object-type name="QVideoSurfaceFormat"/>
 <object-type name="QCameraViewfinder"/>
 <object-type name="QGraphicsVideoItem"/>
+<rejection class="QGraphicsVideoItem" enum-name="enum_1"/>
 <object-type name="QVideoWidget"/>
 <object-type name="QAbstractAudioDeviceInfo"/>
 <object-type name="QAbstractAudioInput"/>

--- a/generator/typesystem_network.xml
+++ b/generator/typesystem_network.xml
@@ -5,10 +5,6 @@
   </namespace-type>
 
   <rejection class="QSqlError::Unused"/>
-  <rejection class="QSslConfiguration" function-name="defaultDtlsConfiguration"/>
-  <rejection class="QSslConfiguration" function-name="dtlsCookieVerificationEnabled"/>
-  <rejection class="QSslConfiguration" function-name="setDefaultDtlsConfiguration"/>
-  <rejection class="QSslConfiguration" function-name="setDtlsCookieVerificationEnabled"/>
 
   <enum-type name="QSsl::AlertLevel" since-version="6"/>
   <enum-type name="QSsl::AlertType" since-version="6"/>
@@ -112,8 +108,6 @@
   </object-type>
   <object-type name="QNetworkCookieJar"/>
   <object-type name="QNetworkReply">
-    <modify-function signature="setSslConfiguration(QSslConfiguration)" remove="all"/>
-    <modify-function signature="sslConfiguration() const" remove="all"/>
     <modify-function signature="ignoreSslErrors(const QList&lt;QSslError&gt;&amp;)" remove="all"/>
   </object-type>
 
@@ -174,8 +168,6 @@
   </value-type>
   <value-type name="QNetworkRequest">
     <modify-function signature="operator=(QNetworkRequest)" remove="all"/>
-    <modify-function signature="setSslConfiguration(QSslConfiguration)" remove="all"/>
-    <modify-function signature="sslConfiguration() const" remove="all"/>
   </value-type>
 
   <enum-type name="QSslError::SslError"/>
@@ -193,6 +185,8 @@
     </extra-includes>
   </value-type>
   <value-type name="QSslConfiguration"/>
+  <value-type name="QSslDiffieHellmanParameters" since-version="5.8"/>
+  <enum-type name="QSslDiffieHellmanParameters::Error" since-version="5.8"/>
 
   <object-type name="QSslSocket"/>
 
@@ -236,10 +230,17 @@
   <object-type name="QDtls" since-version="5.12"/>
   <enum-type name="QDtls::HandshakeState" since-version="5.12"/>
   <object-type name="QDtlsClientVerifier" since-version="5.12"/>
+  <value-type name="QDtlsClientVerifier::GeneratorParameters" since-version="5.12"/>
   
   <object-type name="QHttp1Configuration" since-version="6.5"/>
+  <rejection class="QHttp1Configuration::ShortData" since-version="6.5"/>
+  <rejection class="QHttp1Configuration::U" since-version="6.5"/>
   <object-type name="QHttp2Configuration" since-version="5.14"/>
-  
+
+  <object-type name="QOcspResponse" since-version="5.13"/>
+  <enum-type name="QOcspCertificateStatus" since-version="5.13"/>
+  <enum-type name="QOcspRevocationReason" since-version="5.13"/>
+
   <object-type name="QNetworkInformation" since-version="6.1"/>
   <enum-type name="QNetworkInformation::Feature" flags="QNetworkInformation::Features" since-version="6.1"/>
 

--- a/generator/typesystem_qml.xml
+++ b/generator/typesystem_qml.xml
@@ -6,6 +6,14 @@
 <rejection class="QQmlListProperty"/>
 <rejection class="QQmlTypeInfo"/>
 <rejection class="QQmlImageProviderBase"/>
+<rejection class="QQmlContext::PropertyPair"/>
+<rejection class="QQmlEngineExtensionInterface"/>
+<rejection class="QQmlEngineExtensionPlugin"/>
+<rejection class="QQmlModuleRegistration"/>
+<rejection class="QQmlTriviallyDestructibleDebuggingEnabler"/>
+<rejection class="QQmlTypeNotAvailable"/>
+<rejection class="QmlTypeAndRevisionsRegistration"/>
+<rejection enum-name="QQmlModuleImportSpecialVersions"/>
 
 <object-type name="QJSEngine">
   <modify-function signature="newQMetaObject()" remove="all"/>
@@ -16,6 +24,13 @@
   <modify-function signature="operator++(int)" remove="all"/>
   <modify-function signature="operator--(int)" remove="all"/>
 </object-type>
+<rejection class="QJSPrimitiveValue::AddOperators" since-version="6.1"/>
+<rejection class="QJSPrimitiveValue::DivOperators" since-version="6.1"/>
+<rejection class="QJSPrimitiveValue::MulOperators" since-version="6.1"/>
+<rejection class="QJSPrimitiveValue::QJSPrimitiveValuePrivate" since-version="6.1"/>
+<rejection class="QJSPrimitiveValue::StringNaNOperators" since-version="6.1"/>
+<rejection class="QJSPrimitiveValue::SubOperators" since-version="6.1"/>
+
 <object-type name="QJSPrimitiveUndefined" since-version="6.1"/>
 <object-type name="QJSPrimitiveNull" since-version="6.1"/>
 

--- a/generator/typesystem_quick.xml
+++ b/generator/typesystem_quick.xml
@@ -29,9 +29,16 @@
 <object-type name="QQuickTextDocument"></object-type>
 <object-type name="QQuickTransform"></object-type>
 <object-type name="QQuickView"></object-type>
-<object-type name="QQuickWindow"></object-type>
+<object-type name="QQuickWindow"/>
+<object-type name="QQuickWindow::GraphicsStateInfo" since-version="5.14"/>
 
-<object-type name="QQuickWidget"></object-type>
+<object-type name="QQuickWidget"/>
+
+<object-type name="QQuickGraphicsConfiguration" since-version="6"/>
+<rejection class="QQuickGraphicsDevice" since-version="6"/>
+<object-type name="QQuickRenderTarget" since-version="6"/>
+<!-- Linker error on GitHub CI (Windows, Qt 6.5): -->
+<rejection class="QQuickRenderTarget" function-name="fromVulkanImage" since-version="6"/>
 
 <object-type name="QSGAbstractRenderer"></object-type>
 <object-type name="QSGBasicGeometryNode"></object-type>

--- a/generator/typesystem_webenginewidgets.xml
+++ b/generator/typesystem_webenginewidgets.xml
@@ -5,9 +5,13 @@
     </object-type>
     <object-type name="QWebEnginePage">
     </object-type>
+
+  <object-type name="QWebChannel"/>
+  <object-type name="QWebChannelAbstractTransport"/>
   
   <object-type name="QWebEngineCertificateError"/>
   <object-type name="QWebEngineCookieStore"/>
+  <value-type name="QWebEngineCookieStore::FilterRequest" since-version="5.11"/>
   <object-type name="QWebEngineDownloadItem"/>
   <object-type name="QWebEngineFullScreenRequest"/>
   <object-type name="QWebEngineHistory"/>
@@ -22,8 +26,14 @@
   <object-type name="QWebEngineUrlRequestInterceptor"/>
   <object-type name="QWebEngineUrlRequestJob"/>
   <object-type name="QWebEngineUrlSchemeHandler"/>
+  <object-type name="QWebEngineUrlScheme" since-version="5.12"/>
+  <enum-type name="QWebEngineUrlScheme::Flag" flags="QWebEngineUrlScheme::Flags" since-version="5.12"/>
+  <enum-type name="QWebEngineUrlScheme::SpecialPort" since-version="5.12"/>
+  <enum-type name="QWebEngineUrlScheme::Syntax" since-version="5.12"/>
   <object-type name="QWebEngineNotification" since-version="5.13"/>
+  <object-type name="QWebEngineClientCertificateSelection" since-version="5.12"/>
   <object-type name="QWebEngineClientCertificateStore" since-version="5.13"/>
+  <object-type name="QWebEngineFindTextResult" since-version="5.14"/>
   <object-type name="QWebEngineLoadingInfo" since-version="6.2"/>
   <enum-type name="QWebEngineLoadingInfo::ErrorDomain" since-version="6.2"/>
   <enum-type name="QWebEngineLoadingInfo::LoadStatus" since-version="6.2"/>
@@ -31,12 +41,20 @@
   <enum-type name="QWebEngineContextMenuRequest::EditFlag" flags="QWebEngineContextMenuRequest::EditFlags" since-version="6.2"/>
   <enum-type name="QWebEngineContextMenuRequest::MediaFlag" flags="QWebEngineContextMenuRequest::MediaFlags" since-version="6.2"/>
   <enum-type name="QWebEngineContextMenuRequest::MediaType" since-version="6.2"/>
+  <object-type name="QWebEngineDownloadRequest" since-version="6"/>
+  <enum-type name="QWebEngineDownloadRequest::DownloadInterruptReason" since-version="6"/>
+  <enum-type name="QWebEngineDownloadRequest::DownloadState" since-version="6"/>
+  <enum-type name="QWebEngineDownloadRequest::SavePageFormat" since-version="6"/>
   <object-type name="QWebEngineNavigationRequest" since-version="6.2"/>
   <object-type name="QWebEngineNewWindowRequest" since-version="6.2"/>
   <enum-type name="QWebEngineNewWindowRequest::DestinationType" since-version="6.2"/>
   <object-type name="QWebEngineFileSystemAccessRequest" since-version="6.4"/>
   <enum-type name="QWebEngineFileSystemAccessRequest::AccessFlag" flags="QWebEngineFileSystemAccessRequest::AccessFlags" since-version="6.4"/>
   <enum-type name="QWebEngineFileSystemAccessRequest::HandleType" since-version="6.4"/>
+  <object-type name="QWebEngineHttpRequest" since-version="5.9"/>
+  <enum-type name="QWebEngineHttpRequest::Method" since-version="5.9"/>
+  <object-type name="QWebEngineQuotaRequest" since-version="5.11"/>
+  <object-type name="QWebEngineRegisterProtocolHandlerRequest" since-version="5.11"/>
 
   <enum-type name="QWebEngineCertificateError::Error"/>
   <enum-type name="QWebEngineDownloadItem::DownloadState"/>

--- a/generator/typesystem_xml.xml
+++ b/generator/typesystem_xml.xml
@@ -181,6 +181,7 @@
       <modify-function signature="QXmlStreamReader(const char*)" remove="all"/>
       <modify-function signature="addData(const char*)" remove="all"/>
     </object-type>
+    <rejection class="QXmlStreamReader::PrivateConstructorTag"/>
     <object-type name="QXmlStreamWriter">
         <modify-function signature="QXmlStreamWriter(QString *)">
             <remove/>


### PR DESCRIPTION
Just so that there are no unknown rejected classes and enums in the log file for Qt 6.6. The support for some of the new classes might be incomplete.

One notable addition is the Cbor support in Qt. I got a little bit creative with the supporting classes like QCborTag (which is just a qint64 in Python now), and QCborNegativeInteger (which is simply not supported). Also the string reading methods of QCborStreamReader were modified, because PythonQt can't currently support arbitrary templated parameter/return types. If somebody wants to provide a patch to make it match the C++ interface...

I also re-allowed some methods in QtNetwork which might break compilation if Qt is compiled without SSL support. If this is a problem, please add a comment.