### PR TITLE
Force C++11 for older Qt versions with obsolete compilers (f.e. GCC 4.9.2)

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -2137,8 +2137,9 @@ PyObject* PythonQtPrivate::packageByName(const char* name)
     v = PyImport_AddModule((_pythonQtModuleName + "." + name).constData());
     _packages.insert(name, v);
     // AddObject steals the reference, so increment it!
-    Py_INCREF(v);
-    PyModule_AddObject(_pythonQtModule, name, v);
+    if (PyModule_AddObject(_pythonQtModule, name, v) == 0) {
+      Py_INCREF(v);
+    }
   }
   return v;
 }

--- a/src/src.pri
+++ b/src/src.pri
@@ -2,6 +2,8 @@ DEFINES +=  PYTHONQT_EXPORTS
 
 INCLUDEPATH += $$PWD
 
+CONFIG += c++11
+
 gcc:!no_warn:!clang:QMAKE_CXXFLAGS += -Wno-error=missing-field-initializers
 *-clang*:!no_warn:QMAKE_CXXFLAGS += -Wno-error=sometimes-uninitialized
 


### PR DESCRIPTION
+ small fix for rare problem, but this reference management pattern is safer and preferable 