### PR TITLE
Ignore static_assert in header files

### DIFF
--- a/generator/parser/rpp/pp-qt-configuration
+++ b/generator/parser/rpp/pp-qt-configuration
@@ -31,3 +31,6 @@
 #define Q_ENUM_NS(x)
 #define Q_FLAG_NS(x)
 #define Q_MOC_INCLUDE(...)
+
+// ignore static_assert
+#define static_assert(...)


### PR DESCRIPTION
(appeared in QMessageBox in Qt 6.6.2)