### PR TITLE
Replace deprecated include qsql.h with qtsqlglobal.h for Qt 6

### DIFF
--- a/generator/typesystem_sql.xml
+++ b/generator/typesystem_sql.xml
@@ -7,7 +7,8 @@
   <enum-type name="QSqlDriver::DbmsType"/>
 
   <namespace-type name="QSql">
-     <include file-name="qsql.h" location="global"/>
+     <include file-name="qsql.h" location="global" before-version="6"/>
+     <include file-name="qtsqlglobal.h" location="global" since-version="6"/>
   </namespace-type>
 
   <value-type name="QSqlDatabase">


### PR DESCRIPTION
Fixes #195