### PR TITLE
fix format-security

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -105,7 +105,7 @@ namespace
             includes << (frameworkDir + "/QtOpenGL.framework/Headers");
             includes << frameworkDir;
 #else
-        qWarning((reason + "This may cause problems with finding the necessary include files.").toUtf8().constData());
+        qWarning() << reason << "This may cause problems with finding the necessary include files.";
 #endif
       }
       else


### PR DESCRIPTION
Hi,

This PR fix, on Arch, with GCC 13.2.1:

```cpp
make[1]: Entering directory '/home/nim/aur/pythonqt/src/pythonqt-3.5.0/generator'
g++ -c -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -Wno-deprecated-declarations -pedantic -Winit-self -Wuninitialized -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -fcf-protection -Wp,-D_GLIBCXX_ASSERTIONS -flto -fno-fat-lto-objects -Wall -Wextra -D_REENTRANT -fPIC -DRXX_ALLOCATOR_INIT_0 -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_GUI_LIB -DQT_XML_LIB -DQT_CORE_LIB -I. -I. -I. -I/home/nim/aur/pythonqt/src/pythonqt-3.5.0/generator/../common -Iparser -Iparser/rpp -Iparser/rpp -I/usr/include/qt -I/usr/include/qt/QtGui -I/usr/include/qt/QtXml -I/usr/include/qt/QtCore -I. -I/usr/lib/qt/mkspecs/linux-g++ -o main.o main.cpp
main.cpp:108:17: error: format not a string literal and no format arguments [-Werror=format-security]
  108 |         qWarning((reason + "This may cause problems with finding the necessary include files.").toUtf8().constData());
```