### PR TITLE
Fix small issues in build and tests.

### DIFF
--- a/generator/generatorsetqtscript.cpp
+++ b/generator/generatorsetqtscript.cpp
@@ -54,7 +54,7 @@ GeneratorSetQtScript::GeneratorSetQtScript()
 QString GeneratorSetQtScript::usage() {
     QString usage =
         "QtScript:\n" 
-        "  --nothing-to-report-yet                   \n";
+        "  --nothing-to-report-yet                   \n"
         "  --max-classes-per-file=<n>                \n";
 
     return usage;

--- a/generator/typeparser.cpp
+++ b/generator/typeparser.cpp
@@ -122,6 +122,7 @@ Scanner::Token Scanner::nextToken()
                     m_pos += 2;
                     break;
                 }
+            Q_FALLTHROUGH();
             default:
                 if (c.isLetterOrNumber() || c == '_')
                     tok = Identifier;

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -155,8 +155,8 @@ class Handler : public QXmlDefaultHandler
 public:
     Handler(TypeDatabase *database, unsigned int qtVersion, bool generate)
         : m_database(database)
-        , m_qtVersion(qtVersion)
         , m_generate(generate ? TypeEntry::GenerateAll : TypeEntry::GenerateForSubclass)
+        , m_qtVersion(qtVersion)
     {
         m_current_enum = 0;
         current = 0;

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -295,7 +295,7 @@ bool PythonQtClassInfo::lookForEnumAndCache(const QMetaObject* meta, const char*
           PythonQtMemberInfo newInfo(enumValuePtr);
           _cachedMembers.insert(memberName, newInfo);
   #ifdef PYTHONQT_DEBUG
-          std::cout << "caching enum " << memberName << " on " << meta->className()->constData() << std::endl;
+          std::cout << "caching enum " << memberName << " on " << meta->className() << std::endl;
   #endif
           found = true;
           break;

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -52,7 +52,7 @@ bool PythonQtSlotInfo::_globalShouldAllowThreads = false;
 PythonQtMethodInfo::PythonQtMethodInfo(const QMetaMethod& meta, PythonQtClassInfo* classInfo)
 {
 #ifdef PYTHONQT_DEBUG
-  QByteArray sig = PythonQtUtils::signature(meta));
+  QByteArray sig = PythonQtUtils::signature(meta);
   sig = sig.mid(sig.indexOf('('));
   QByteArray fullSig = QByteArray(meta.typeName()) + " " + sig;
   std::cout << "caching " << fullSig.data() << std::endl;

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -193,7 +193,11 @@ void PythonQtTestSlotCalling::testPODSlotCalls()
   QVERIFY(_helper->runScript("if obj.getUInt(42)==42: obj.setPassed();\n"));
   QVERIFY(_helper->runScript("if obj.getShort(-43)==-43: obj.setPassed();\n"));
   QVERIFY(_helper->runScript("if obj.getUShort(43)==43: obj.setPassed();\n"));
+#if (CHAR_MIN + 0)
   QVERIFY(_helper->runScript("if obj.getChar(-12)==-12: obj.setPassed();\n"));
+#else
+  QVERIFY(_helper->runScript("if obj.getChar(250)==250: obj.setPassed();\n"));
+#endif
   QVERIFY(_helper->runScript("if obj.getUChar(12)==12: obj.setPassed();\n"));
   QVERIFY(_helper->runScript("if obj.getLong(-256*256*256)==-256*256*256: obj.setPassed();\n"));
   QVERIFY(_helper->runScript("if obj.getULong(256*256*256)==256*256*256: obj.setPassed();\n"));

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -9,7 +9,7 @@ TEMPLATE = app
 DESTDIR    = ../lib
 QMAKE_RPATHDIR += $$DESTDIR
 
-QT += testlib opengl
+QT += testlib
 CONFIG += testcase cmdline exceptions testcase_no_bundle no_testcase_installs
 
 #Workaround for MinGW build. Qt incorrectly sets it to empty string on Win32 for bash


### PR DESCRIPTION
* Main change: `CHAR_MIN` is `0` for unsigned `char`. In general, the "sign-ness" of the `char` type is implementation-specific. There is a proper check in the type conversion facility, but the test-case supposes the `char` to be signed, that is wrong.

* `opengl` is not required for tests (fix build without `opengl` module)
* Fix build with PYTHONQT_DEBUG enabled
* Small fixes to build with less warnings.