### PR TITLE
6.6.3 introduced a new helper class for QOperatingSystemVersion

### DIFF
--- a/generator/typesystem_core.xml
+++ b/generator/typesystem_core.xml
@@ -2272,6 +2272,7 @@ public:
   <object-type name="QDeadlineTimer"/>
   <object-type name="QOperatingSystemVersionBase"/>
   <enum-type name="QOperatingSystemVersionBase::OSType"/>
+  <object-type name="QOperatingSystemVersionUnexported" since-version="6.6.3"/>
   <object-type name="QOperatingSystemVersion"/>
   <enum-type name="QOperatingSystemVersion::OSType"/>
   <object-type name="QRandomGenerator"/>


### PR DESCRIPTION
This class (QOperatingSystemVersionUnexported) must be generated to provide the proper inheritance of methods.