### PR TITLE
fix format-security on Q_OS_MAC

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -96,7 +96,7 @@ namespace
         QString reason = "The QTDIR environment variable " + qtdir.isEmpty() ?
                          "is not set. " : "points to a non-existing directory. ";
 #if defined(Q_OS_MAC)
-        qWarning((reason + "Assuming standard binary install using frameworks.").toUtf8().constData());
+        qWarning() << reason << "Assuming standard binary install using frameworks.";
             QString frameworkDir = "/Library/Frameworks";
             includes << (frameworkDir + "/QtXml.framework/Headers");
             includes << (frameworkDir + "/QtNetwork.framework/Headers");

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -80,7 +80,7 @@ namespace
       {
         if (!QDir(*it).exists())
         {
-          qWarning("Include path %s does not exist, ignoring it.", it->toUtf8().constData());
+          qWarning() << "Include path " << it->toUtf8() << "does not exist, ignoring it.";
           it = includes.erase(it);
         }
         else

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -80,7 +80,7 @@ namespace
       {
         if (!QDir(*it).exists())
         {
-          qWarning() << "Include path " << it->toUtf8() << "does not exist, ignoring it.";
+          qWarning() << "Include path " << it->toUtf8() << " does not exist, ignoring it.";
           it = includes.erase(it);
         }
         else

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -239,24 +239,25 @@ private:
 
 bool Handler::error(const QXmlParseException &e)
 {
-    qWarning("Error: line=%d, column=%d, message=%s\n",
-             e.lineNumber(), e.columnNumber(), qPrintable(e.message()));
+    qWarning() << "Error: line=" << e.lineNumber()
+        << ", column=" << e.columnNumber()
+        << ", message=" << e.message() << "\n";
     return false;
 }
 
 bool Handler::fatalError(const QXmlParseException &e)
 {
-    qWarning("Fatal error: line=%d, column=%d, message=%s\n",
-             e.lineNumber(), e.columnNumber(), qPrintable(e.message()));
-
+    qWarning() << "Fatal error: line=" << e.lineNumber()
+        << ", column=" << e.columnNumber()
+        << ", message=" << e.message() << "\n";
     return false;
 }
 
 bool Handler::warning(const QXmlParseException &e)
 {
-    qWarning("Warning: line=%d, column=%d, message=%s\n",
-             e.lineNumber(), e.columnNumber(), qPrintable(e.message()));
-
+    qWarning() << "Warning: line=" << e.lineNumber()
+        << ", column=" << e.columnNumber()
+        << ", message=" << e.message() << "\n";
     return false;
 }
 
@@ -1737,7 +1738,7 @@ QString ContainerTypeEntry::targetLangName() const
         //     case MultiHashCollectio: return "MultiHash";
     case PairContainer: return "QPair";
     default:
-        qWarning("bad type... %d", m_type);
+        qWarning() << "bad type... " << m_type;
         break;
     }
     return QString();
@@ -2147,4 +2148,3 @@ unsigned int TypeSystem::qtVersionFromString(const QString& value, bool& ok)
   }
   return result;
 }
-


### PR DESCRIPTION
Hi,

This is the following #197, except it is on macos with clang 16.0.6:
```
main.cpp:99:18: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
        qWarning((reason + "Assuming standard binary install using frameworks.").toUtf8().constData());
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
main.cpp:99:18: note: treat the string as an argument to avoid this
        qWarning((reason + "Assuming standard binary install using frameworks.").toUtf8().constData());
                 ^
                 "%s",