### PR TITLE
Allow to set and get the render API in QQuickWindow

### DIFF
--- a/generator/typesystem_quick.xml
+++ b/generator/typesystem_quick.xml
@@ -73,7 +73,14 @@
 <object-type name="QSGRectangleNode"/>
 <object-type name="QSGRenderNode"/>
 <object-type name="QSGRenderNode::RenderState"/>
-<rejection class="QSGRendererInterface"/>
+<interface-type name="QSGRendererInterface"/>
+<enum-type name="QSGRendererInterface::GraphicsApi"/>
+<rejection class="QSGRendererInterface" function-name="getResource"/>
+<enum-type name="QSGRendererInterface::ShaderType"/>
+<enum-type name="QSGRendererInterface::ShaderCompilationType" flags="QSGRendererInterface::ShaderCompilationTypes"/>
+<enum-type name="QSGRendererInterface::ShaderSourceType" flags="QSGRendererInterface::ShaderSourceTypes"/>
+<enum-type name="QSGRendererInterface::RenderMode"/>
+<rejection class="QSGRendererInterface" enum-name="Resource"/>
 
 <enum-type name="QSGImageNode::TextureCoordinatesTransformFlag"/>
 <enum-type name="QSGRenderNode::RenderingFlag"/>


### PR DESCRIPTION
Otherwise one can't switch the desired render API for the QtQuick framework.

(We need this in the MeVisLab context.)