### PR TITLE
QPixmapCache::find(QString, QPixmap*) was suppressed

### DIFF
--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -1417,10 +1417,6 @@ PyObject* constScanLine(QImage* image, int line) {
   </object-type>
 
   <object-type name="QPixmapCache">
-    <modify-function signature="find(QString)">
-        <remove/>
-    </modify-function>
-    <modify-function signature="find(QString,QPixmap*)" remove="all"/>
   </object-type>
   <object-type name="QPlastiqueStyle">
     <modify-function signature="standardPixmap(QStyle::StandardPixmap, const QStyleOption*, const QWidget*)const" remove="all"/> <!--### Obsolete in 4.3-->


### PR DESCRIPTION
but I don't know why, since the method should simply work (like the other find variant). And it was reported that the method was previously (before Qt6) created, even though it should have been suppressed.