### PR TITLE
Update install-qt-action to v4

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -28,7 +28,7 @@ jobs:
         arch: amd64
 
     - name: Install Qt ${{matrix.qt-version}}
-      uses: jurplel/install-qt-action@v3
+      uses: jurplel/install-qt-action@v4
       with:
         version: ${{ matrix.qt-version }}
         modules: ${{startsWith(matrix.qt-version, '6') && 'qt5compat qtscxml qtpositioning qtwebchannel qtmultimedia qtwebengine' || '' }}
@@ -50,12 +50,9 @@ jobs:
         echo "QT_VERSION_MAJOR=$QT_VERSION_MAJOR" >> $GITHUB_ENV
         QT_VERSION_SHORT=$(cut -f 1,2 -d . <<< "${{matrix.qt-version}}")
         echo "QT_VERSION_SHORT=$QT_VERSION_SHORT" >> $GITHUB_OUTPUT
-        QTDIR=$(eval echo "\$Qt${QT_VERSION_MAJOR}_DIR")
         PYTHON_VERSION_FULL=$(python --version 2>&1 | cut -f 2 -d ' ')
         PYTHON_VERSION_SHORT=$(cut -f 1,2 -d . <<< $PYTHON_VERSION_FULL)
         echo "PYTHON_VERSION_SHORT=$PYTHON_VERSION_SHORT" >> $GITHUB_OUTPUT
-        echo "QTDIR=$QTDIR" >> $GITHUB_ENV
-        echo "$QTDIR/bin" >> $GITHUB_PATH
         echo "$pythonLocation/bin" >> $GITHUB_PATH
 
     - name: Build generator Ubuntu
@@ -79,7 +76,7 @@ jobs:
       shell: bash
       run: |
         cd generator
-        if [[ ${{ matrix.os }} == 'windows' && ${{ matrix.qt-version }} =~ '5.1' ]]; then export QTDIR=$Qt5_Dir; fi 
+        QTDIR="$QT_ROOT_DIR" \
         UBSAN_OPTIONS="halt_on_error=1" \
         ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
         ./pythonqt_generator


### PR DESCRIPTION
New environment variable `QT_ROOT_DIR` should be used instead of `Qt5_Dir`/`Qt6_Dir`.
Also, `PATH` is now correctly updated by install-qt-action, thus no workaround setting `GITHUB_PATH` is required. 
See https://github.com/jurplel/install-qt-action/blob/v4/README_upgrade_guide.md