### PR TITLE
Fix macOS and CentOS CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,14 @@ on:
     branches: 
       - master
   pull_request:
-      
+   
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+   
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+    
 defaults:
   run:
     shell: bash
@@ -93,6 +100,13 @@ jobs:
     runs-on: ubuntu-latest
     container: '${{ matrix.container_os }}:${{ matrix.container_os_version }}'
     steps:
+    - name: Change centos archive repository
+      run: |
+        sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+        sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+        sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+      if: matrix.container_os == 'centos'
+      
     - name: Install Qt
       run: |
         yum update -y
@@ -147,8 +161,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       macos-version:  ['11']
-       python-version: ['3.6']
+       macos-version:  ['12']
+       python-version: ['3.9']
        qt-version: ['5.9.*']
        configuration: ['release','debug']
        include:


### PR DESCRIPTION
1. [CentOS7 reached EOL](https://www.redhat.com/en/topics/linux/centos-linux-eol) and GHA support for the corresponding [container was abandoned](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/). However, `node20` requires at least `glibc2.27`, which is not available in CentOS, but upgrading the glibc version contradicts the meaning of using older CentOS. The proposed solution in this PR is to use corresponding environment variable, that helps to extend CentOS CI availability for some time. Also,  `mirrorlist.centos.org` was turned off, so switch [to vault](https://serverfault.com/questions/904304/could-not-resolve-host-mirrorlist-centos-org-centos-7) is required (see `sed` for configs in PR)

2. [macOS-11 runner is no longer supported on GHA](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal), thus macOS-12 with python3.9 is proposed
 
3. Small feature: cancel running workflow from the same PR.