### PR TITLE
Fix memory leak and add memory tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,11 +73,13 @@ jobs:
       run: |
         QT_VERSION_FULL=$(qmake -query QT_VERSION)
         if [[ "$QT_VERSION_FULL" == 5.12* ]]; then
-          export LSAN_OPTIONS="suppressions=leak:QPlatformIntegrationFactory::create"
+          echo "leak:QPlatformIntegrationFactory::create" >> $PWD/lsan.supp
+          export LSAN_OPTIONS="suppressions=$PWD/lsan.supp"
         fi
         PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
-        PYTHONQT_RUN_ONLY_MEMORY_TESTS="true" make check TESTARGS="-platform minimal"
+        PYTHONQT_RUN_ONLY_MEMORY_TESTS=1 \
+          make check TESTARGS="-platform minimal"
       
     - name: Generate Wrappers
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,6 +68,16 @@ jobs:
         PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
           make check TESTARGS="-platform offscreen"
+        
+    - name: Run memory tests with sanitizers
+      run: |
+        QT_VERSION_FULL=$(qmake -query QT_VERSION)
+        if [[ $QT_VERSION_FULL == 5.12* ]]; then
+          export LSAN_OPTIONS="suppressions=leak:QPlatformIntegrationFactory::create"
+        fi
+        PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=1:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        PYTHONQT_RUN_ONLY_MEMORY_TESTS="true" make check TESTARGS="-platform minimal"
       
     - name: Generate Wrappers
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Run memory tests with sanitizers
       run: |
         QT_VERSION_FULL=$(qmake -query QT_VERSION)
-        if [[ $QT_VERSION_FULL == 5.12* ]]; then
+        if [[ "$QT_VERSION_FULL" == 5.12* ]]; then
           export LSAN_OPTIONS="suppressions=leak:QPlatformIntegrationFactory::create"
         fi
         PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1898,7 +1898,11 @@ void PythonQt::initPythonQtModule(bool redirectStdOut, const QByteArray& pythonQ
   Py_XDECREF(old_module_names);
 
 #ifdef PY3K
-  PyDict_SetItem(PyObject_GetAttrString(sys.object(), "modules"), PyUnicode_FromString(name.constData()), _p->_pythonQtModule.object());
+  PyObject* modulesAttr = PyObject_GetAttrString(sys.object(), "modules");
+  PyObject* pyUnicodeObject = PyUnicode_FromString(name.constData());
+  PyDict_SetItem(modulesAttr, pyUnicodeObject, _p->_pythonQtModule.object());
+  Py_XDECREF(modulesAttr);
+  Py_XDECREF(pyUnicodeObject);
 #endif
 }
 

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -48,8 +48,13 @@ int main( int argc, char **argv )
 {
   QApplication qapp(argc, argv);
 
-  PythonQt::init(PythonQt::IgnoreSiteModule | PythonQt::RedirectStdOut);
+  if (QProcessEnvironment::systemEnvironment().contains("PYTHONQT_RUN_ONLY_MEMORY_TESTS")) {
+    PythonQtMemoryTests test;
+    QTest::qExec(&test, argc, argv);
+    return 0;
+  }
 
+  PythonQt::init(PythonQt::IgnoreSiteModule | PythonQt::RedirectStdOut);
   int failCount = 0;
   PythonQtTestApi api;
   failCount += QTest::qExec(&api, argc, argv);

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -69,7 +69,7 @@ void PythonQtMemoryTests::testSeveralCleanup() {
 }
 
 void PythonQtMemoryTests::testInitWithPreconfig() {
-#if PY_VERSION_HEX >= 0x030800
+#if PY_VERSION_HEX >= 0x03080000
   PyConfig config;
   PyConfig_InitPythonConfig(&config);
   Py_InitializeFromConfig(&config);

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -41,6 +41,43 @@
 
 #include "PythonQtTests.h"
 
+void PythonQtMemoryTests::testBaseCleanup()
+{
+  PythonQt::init();
+  PythonQt::cleanup();
+}
+
+void PythonQtMemoryTests::testCleanupWithFlags()
+{
+  PythonQt::init(PythonQt::IgnoreSiteModule | PythonQt::RedirectStdOut);
+  PythonQt::cleanup();
+}
+
+void PythonQtMemoryTests::testInitAlreadyInitialized()
+{
+  Py_InitializeEx(true);
+  PythonQt::init(PythonQt::PythonAlreadyInitialized);
+  PythonQt::cleanup();
+}
+
+void PythonQtMemoryTests::testSeveralCleanup() {
+  PythonQt::init();
+  PythonQt::cleanup();
+
+  PythonQt::init();
+  PythonQt::cleanup();
+}
+
+void PythonQtMemoryTests::testInitWithPreconfig() {
+#if PY_VERSION_HEX >= 0x030800
+  PyConfig config;
+  PyConfig_InitPythonConfig(&config);
+  Py_InitializeFromConfig(&config);
+  PythonQt::init(PythonQt::RedirectStdOut | PythonQt::PythonAlreadyInitialized);
+  PythonQt::cleanup();
+#endif
+}
+
 void PythonQtTestSlotCalling::initTestCase()
 {
   _helper = new PythonQtTestSlotCallingHelper(this);

--- a/tests/PythonQtTests.h
+++ b/tests/PythonQtTests.h
@@ -58,6 +58,18 @@ class PythonQtTestSlotCallingHelper;
 class PythonQtTestApiHelper;
 class QWidget;
 
+class PythonQtMemoryTests : public QObject
+{
+  Q_OBJECT
+
+private Q_SLOTS:
+  void testBaseCleanup();
+  void testCleanupWithFlags();
+  void testSeveralCleanup();
+  void testInitWithPreconfig();
+  void testInitAlreadyInitialized();
+};
+
 //! test the PythonQt api
 class PythonQtTestApi : public QObject
 {


### PR DESCRIPTION
1. [PyUnicode_FromString](https://docs.python.org/3/c-api/unicode.html#c.PyUnicode_FromString) returns a new reference, thus memory leak took place and is fixed.
2. To diagnose such leaks, basic memory tests are implemented, that to be extended later. To run these memory tests the  `PYTHONQT_RUN_ONLY_MEMORY_TESTS` environment variable should be used. 
3. These tiny specialized memory tests are temporary useful until memleaks are fixed in `PythonQt::cleanup` for general main tests.
4. So, this PR adds a CI step to run mentioned memory tests with Leak Sanitizer turned on via  `ASAN_OPTIONS=detect_leaks=1`.