### PR TITLE
Fix memory leak with PyDict_Copy

### DIFF
--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -383,8 +383,9 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
   }
 
   if (qstrcmp(attributeName, "__dict__")==0) {
-    PyObject* dict = PyBaseObject_Type.tp_getattro(obj, name);
-    dict = PyDict_Copy(dict);
+    PyObject* objectDict = PyBaseObject_Type.tp_getattro(obj, name);
+    PyObject* dict = PyDict_Copy(objectDict);
+    Py_DECREF(objectDict);
 
     if (wrapper->_obj) {
       // we need to replace the properties with their real values...


### PR DESCRIPTION
`PyBaseObject_Type.tp_getattro` uses `PyObject_GenericGetAttr`, which returns a [new reference](https://docs.python.org/3/c-api/object.html#c.PyObject_GenericGetAttr) that is lost when using PyDict_Copy.