### PR TITLE
Fix Qt 6.7.3

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -1137,10 +1137,15 @@ void AbstractMetaBuilder::traverseFunctions(ScopeModelItem scope_item, AbstractM
             if (meta_function->isDestructor() && !meta_function->isFinal())
                 meta_class->setForceShellClass(true);
 
-            if (!meta_function->isDestructor()
-                && !meta_function->isInvalid()
-                && (!meta_function->isConstructor() || !meta_function->isPrivate())) {
-
+            if (meta_function->name().startsWith("__") && meta_function->isStatic()) {
+                // static operators are not supported by PythonQt
+                // (this only seems to happen for static operators in namespaces)
+                delete meta_function;
+            }
+            else if (!meta_function->isDestructor()
+                     && !meta_function->isInvalid()
+                     && (!meta_function->isConstructor() || !meta_function->isPrivate()))
+            {
                 if (meta_class->typeEntry()->designatedInterface() && !meta_function->isPublic()
                     && !meta_function->isPrivate()) {
                     QString warn = QString("non-public function '%1' in interface '%2'")

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -316,7 +316,7 @@ bool ShellGenerator::functionHasNonConstReferences(const AbstractMetaFunction* f
       QTextStream t(&s);
       t << function->implementingClass()->qualifiedCppName() << "::";
       writeFunctionSignature(t, function, 0, "",
-        Option(ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
+        Option(ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
       std::cout << s.toLatin1().constData() << std::endl;
       return true;
     }

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -80,7 +80,7 @@ void ShellHeaderGenerator::writeFieldAccessors(QTextStream& s, const AbstractMet
     addIndirection = true;
   }
   writeFunctionSignature(s, getter, 0, QString(),
-    Option(ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces));
+    Option(ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | ShowStatic | UnderscoreSpaces));
   s << "{ return ";
   if (addIndirection) {
     s << "&";
@@ -145,7 +145,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
     for (AbstractMetaFunction * fun :  ctors) {
       s << "    ";
       writeFunctionSignature(s, fun, 0, "PythonQtShell_",
-        Option(IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces));
+        Option(IncludeDefaultExpression | ShowStatic | UnderscoreSpaces));
       s << ":" << meta_class->qualifiedCppName() << "(";
       QString scriptFunctionName = fun->originalName();
       AbstractMetaArgumentList args = fun->arguments();
@@ -164,7 +164,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
 
     for (AbstractMetaFunction * fun :  virtualsForShell) {
       writeFunctionSignature(s, fun, 0, QString(),
-        Option(IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces));
+        Option(IncludeDefaultExpression | ShowStatic | UnderscoreSpaces));
       s << " override;" << endl;
     }
     s << endl;
@@ -212,7 +212,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
         }
         s << "inline ";
         writeFunctionSignature(s, fun, 0, "promoted_",
-          Option(IncludeDefaultExpression | OriginalName | UnderscoreSpaces | ProtectedEnumAsInts));
+          Option(IncludeDefaultExpression | UnderscoreSpaces | ProtectedEnumAsInts));
         s << " { ";
         QString scriptFunctionName = fun->originalName();
         AbstractMetaArgumentList args = fun->arguments();
@@ -239,7 +239,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       if (fun->isVirtual()) {
         s << "inline ";
         writeFunctionSignature(s, fun, 0, "py_q_",
-          Option(IncludeDefaultExpression | OriginalName | UnderscoreSpaces | ProtectedEnumAsInts));
+          Option(IncludeDefaultExpression | UnderscoreSpaces | ProtectedEnumAsInts));
         s << " { ";
         QString scriptFunctionName = fun->originalName();
         AbstractMetaArgumentList args = fun->arguments();
@@ -355,7 +355,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
 
       s << meta_class->qualifiedCppName() << "* ";
       writeFunctionSignature(s, fun, 0, "new_",
-        Option(IncludeDefaultExpression | OriginalName | ShowStatic | AddOwnershipTemplates));
+        Option(IncludeDefaultExpression | ShowStatic | AddOwnershipTemplates));
       s << ";" << endl;
       if (fun->arguments().size() == 1 && meta_class->qualifiedCppName() == fun->arguments().at(0)->type()->typeEntry()->qualifiedCppName()) {
         copyConstructorSeen = true;
@@ -387,14 +387,14 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       //functionHasNonConstReferences(function);
       s << "   ";
       writeFunctionSignature(s, function, 0, QString(),
-        Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
+        Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
       s << ";" << endl;
     }
     if (function->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter()) {
       // qualified version that calls the promoter/the qualified version
       s << "   ";
       writeFunctionSignature(s, function, 0, "py_q_",
-        Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | OriginalName | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
+        Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
       s << "{  ";
 
       QString scriptFunctionName = function->originalName();

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -125,11 +125,11 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
     foreach (const AbstractMetaFunction *fun, virtualsForShell) {
       bool hasReturnValue = !fun->type().isNull();
       writeFunctionSignature(s, fun, meta_class, QString(),
-        Option(OriginalName | ShowStatic | UnderscoreSpaces | UseIndexedName),
+        Option(ShowStatic | UnderscoreSpaces | UseIndexedName),
         "PythonQtShell_");
       s << endl << "{" << endl;
 
-      Option typeOptions = Option(OriginalName | UnderscoreSpaces | SkipName);
+      Option typeOptions = Option(UnderscoreSpaces | SkipName);
       AbstractMetaArgumentList args = fun->arguments();
 
       // we can't handle return values which are references right now, do not send those to Python...
@@ -239,7 +239,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
 
       s << meta_class->qualifiedCppName() << "* ";
       s << "PythonQtWrapper_" << meta_class->name() << "::";
-      writeFunctionSignature(s, ctor, 0, "new_", Option(AddOwnershipTemplates | OriginalName | ShowStatic));
+      writeFunctionSignature(s, ctor, 0, "new_", Option(AddOwnershipTemplates | ShowStatic));
       s << endl;
       s << "{ " << endl;
       s << "return new " << (meta_class->generateShellClass()?shellClassName(meta_class):meta_class->qualifiedCppName()) << "(";
@@ -281,7 +281,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
       continue;
     }
     writeFunctionSignature(s, fun, meta_class, QString(),
-      Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | OriginalName | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts),
+      Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts),
       "PythonQtWrapper_");
     s << endl << "{" << endl;
     s << "  ";

--- a/generator/typesystem_core.xml
+++ b/generator/typesystem_core.xml
@@ -1507,9 +1507,7 @@ public:
   <object-type name="QSemaphore"/>
   <object-type name="QSocketNotifier"/>
   <object-type name="QSystemLocale"/>
-  <object-type name="QTemporaryFile">
-    <modify-function signature="fileName()const" rename="uniqueFilename"/>
-  </object-type>
+  <object-type name="QTemporaryFile"/>
   <object-type name="QMimeData">
     <extra-includes>
       <include file-name="QStringList" location="global"/>

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -797,9 +797,6 @@
   <value-type name="QTextFormat">
     <modify-function signature="operator=(QTextFormat)" remove="all"/>
     <modify-function signature="isValid()const" access="non-final"/>
-
-    <modify-function signature="setProperty(int,QVector&lt;QTextLength&gt;)" rename="setLengthVectorProperty" before-version="6"/>
-    <modify-function signature="setProperty(int,const QList&lt;QTextLength&gt;&amp;)" rename="setLengthVectorProperty" since-version="6"/>
   </value-type>
 
   <value-type name="QTextListFormat"/>
@@ -917,10 +914,6 @@
 
       <modify-function signature="operator*(QMatrix)const" access="private"/>
       <modify-function signature="operator*=(QMatrix)" access="private"/>
-      <modify-function signature="rotate(double)" access="private" rename="rotate_private"/>
-      <modify-function signature="scale(double,double)" access="private" rename="scale_private"/>
-      <modify-function signature="shear(double,double)" access="private" rename="shear_private"/>
-      <modify-function signature="translate(double,double)" access="private" rename="translate_private"/>
   </value-type>
 
   <value-type name="QConicalGradient" polymorphic-id-expression="%1-&gt;type() == QGradient::ConicalGradient">
@@ -1562,8 +1555,6 @@ PyObject* constScanLine(QImage* image, int line) {
   <object-type name="QTextBlockUserData"/>
   <object-type name="QTextItem"/>
   <object-type name="QTextList">
-    <modify-function signature="format()const" rename="textListFormat"/>
-
       <modify-function signature="isEmpty()const" remove="all"/> <!--### Obsolete in 4.3-->
   </object-type>
   <object-type name="QTextObject"/>
@@ -1775,8 +1766,6 @@ PyObject* constScanLine(QImage* image, int line) {
       </modify-argument>
     </modify-function>
 
-    <modify-function signature="setSpacing(int)" rename="setWidgetSpacing"/>
-    <modify-function signature="spacing()const" rename="widgetSpacing"/>
     <modify-function signature="getContentsMargins(int*,int*,int*,int*)const" remove="all"/>
 
     <modify-function signature="margin()const" remove="all"/> <!--### Obsolete in 4.3-->
@@ -1903,9 +1892,6 @@ PyObject* constScanLine(QImage* image, int line) {
 
       <modify-function signature="isHeaderVisible()const" remove="all"/> <!--### Obsolete in 4.3-->
       <modify-function signature="setHeaderVisible(bool)" remove="all"/> <!--### Obsolete in 4.3-->
-  
-      <modify-function signature="sizeHint()const" rename="getSizeHint"/>
-      <modify-function signature="minimumSizeHint()const" rename="getMinimumSizeHint"/>
   </object-type>
 
   <object-type name="QTreeWidget">
@@ -2197,9 +2183,6 @@ PyObject* constScanLine(QImage* image, int line) {
       <modify-function signature="setShown(bool)" remove="all"/> <!--### Obsolete in 4.3-->
       <modify-function signature="topLevelWidget()const" remove="all"/> <!--### Obsolete in 4.3-->
       <modify-function signature="windowActivationChange(bool)" remove="all"/> <!--### Obsolete in 4.3-->
-  
-    <modify-function signature="sizeHint()const" rename="getSizeHint"/>
-    <modify-function signature="minimumSizeHint()const" rename="getMinimumSizeHint"/>
   </object-type>
 
   <object-type name="QMessageBox">


### PR DESCRIPTION
This fixes the problem introduced with Qt 6.7.3, that the wrapper for the "Qt" namespace suddenly got methods like
` QKeyCombination  static_Qt_operator+(Qt::KeyboardModifiers  modifiers, Qt::Key  key);`
The problem is two-fold:

1. No proper name-mangling was applied to these static methods ("operator+" should be replaced by "\_\_add\_\_").
2. Static operators don't work in PythonQt anyway and shouldn't be generated (we also can't assign the operator to the first argument type, since that is only a enum type, which has no separate wrapper generated).

The trigger for these problems was that these static operators have been moved to the Qt namespace in version 6.7.3.
