### PR TITLE
Replace ubuntu 20.04 with ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         container_version:
-        - '20.04'
         - '22.04'
+        - '24.04'
     runs-on: ubuntu-latest
     container: ubuntu:${{ matrix.container_version }}
     steps:


### PR DESCRIPTION
- 20.04 will no longer be supported by GH actions