### PR TITLE
Add clang-format configuration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,174 @@
+Language:        Cpp
+IndentWidth:     2
+UseTab:		Never
+ColumnLimit:     120
+SortIncludes:    false
+AccessModifierOffset: -2
+ReflowComments:  false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterExternBlock: true
+    AfterClass: true
+    AfterFunction: true
+    AfterNamespace: false
+    AfterEnum: false
+    AfterCaseLabel: false  
+    AfterControlStatement: Never
+    AfterStruct:     false
+    AfterUnion:      false
+    BeforeLambdaBody: false
+    BeforeElse: false
+    BeforeCatch:     false
+    BeforeWhile:     false
+    IndentBraces:    false
+    SplitEmptyFunction: true
+    SplitEmptyRecord: false
+    SplitEmptyNamespace: true
+PPIndentWidth: 2
+FixNamespaceComments: false
+# ??????
+IndentPPDirectives: BeforeHash
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+# ??
+#SpacesBeforeTrailingComments: -1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+IndentCaseBlocks: false
+IndentCaseLabels: false
+AlignAfterOpenBracket: DontAlign
+BreakConstructorInitializers: BeforeComma
+AlwaysBreakTemplateDeclarations: true
+NamespaceIndentation: None
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: true
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   Align
+AlignTrailingComments: false
+# ??
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+# AllowShortIfStatementsOnASingleLine: Nevers
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: After
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeConceptDeclarations: Always
+BreakBeforeTernaryOperators: true
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+CompactNamespaces: false
+Cpp11BracedListStyle: true
+PointerAlignment: Right
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Leave
+MaxEmptyLinesToKeep: 1
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+Macros:
+  - >-
+    PyObject_HEAD_INIT(type)={
+        { 0xFFFFFFFF },
+        (type)
+    },
+  - >-
+    PyVarObject_HEAD_INIT(type, size)={
+        {
+            { 0xFFFFFFFF },
+            (type)
+        },
+        (size)
+    },
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+  - Q_OBJECT
+  - PyObject_HEAD
+IndentAccessModifiers: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentRequiresClause: true
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: true
+# ???
+LambdaBodyIndentation: OuterScope
+PackConstructorInitializers: BinPack
+RemoveBracesLLVM: false
+RequiresClausePosition: OwnLine
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortUsingDeclarations: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Latest

--- a/run-clang-format.sh
+++ b/run-clang-format.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -xeuo pipefail
+which -a clang-format-20 > /dev/null \
+	||  (echo -e "20.0.0\n$(clang-format${1+-$1} --version | grep -Eo '([0-9]+\.[0-9]+\.[0-9]+)')" | sort -CV ) \
+		|| { echo "use '${0} <clang-format-version-not-less-than-20>' to call exact proper version" ; exit 1 ; }
+
+IGNORED_DIRS=(
+    "./generated_cpp_50"
+    "./generated_cpp_511"
+    "./generated_cpp_515"
+    "./generated_cpp_53"
+    "./generated_cpp_54"
+    "./generated_cpp_56"
+    "./examples"
+    "./build"
+)
+
+IGNORE_CMD=""
+
+for DIR in "${IGNORED_DIRS[@]}"; do
+    IGNORE_CMD+=" -path $DIR -o"
+done
+
+IGNORE_CMD=${IGNORE_CMD% -o}
+
+find . \( $IGNORE_CMD \) -prune -o -name '*.cpp' -print0 -o -name '*.h' -print0 | xargs -0 clang-format-20 --style=file -i


### PR DESCRIPTION
This `PR` aims to add `ClangFormat` to `PythonQt`. During the [discussion](https://github.com/MeVisLab/pythonqt/discussions/234), it was decided that `clang-format` is a valid solution.
A version of `clang-format-20` or higher is required, and a testing script (`run-clang-format.sh`) has been written for testing and/or running in `CI`.

It is worth noting that the `PythonQt Generator` has a style that differs from the main `src` directory. If this is a priority, you can put a separate `.clang-format` in the `generator` directory, which will override the parent one.

The following steps:

1. Run `run-clang-format.sh` locally
2. If you are satisfied with the formatting result, merge this `PR` (possibly changing some `.clang-format` parameters)
3. Merge formatted code
4. Add `CI`