### PR TITLE
Make the behavior of the build system more obvious

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
         echo ============================
         qmake -r PythonQt.pro CONFIG+=ccache CONFIG+=release CONFIG+=force_debug_info \
-        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address CONFIG+=tests CONFIG+=generator \
         PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
         PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
         make -j $(nproc)
@@ -138,7 +138,7 @@ jobs:
         export PYTHON_DIR=`which python${PYTHON_VERSION_SUFFIX} | xargs dirname | xargs dirname`
         echo PYTHON_VERSION_SHORT=${PYTHON_VERSION_SHORT}
         echo PYTHON_DIR=${PYTHON_DIR}
-        qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} \
+        qmake-qt5 -r PythonQt.pro CONFIG+=${{ matrix.configuration }} CONFIG+=tests CONFIG+=generator \
           "PYTHON_VERSION=${PYTHON_VERSION_SHORT}" "PYTHON_DIR=${PYTHON_DIR}"
         make -j $(nproc) && \
         PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
@@ -225,7 +225,7 @@ jobs:
                  "python${PYTHON_VERSION_MAJOR}-embed" "python${PYTHON_VERSION_MAJOR}"
         do if pkg-config --exists "$i"; then PYTHON_PKGCONFIG_NAME="$i"; break; fi; done
         qmake CONFIG+=ccache CONFIG+=${{ matrix.configuration }} CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
-          PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }} \
+          CONFIG+=tests CONFIG+=generator PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }} \
           PYTHON_DIR="$pythonLocation" \
           PKGCONFIG+=$PYTHON_PKGCONFIG_NAME \
           -r PythonQt.pro
@@ -335,7 +335,8 @@ jobs:
         qmake -query
         python --version
         set PYTHONQTALL_CONFIG=${{ matrix.pythonqtall-config }}
-        qmake CONFIG+=release CONFIG-=debug_and_release CONFIG-=debug_and_release_target ^
+        qmake CONFIG+=release CONFIG-=debug_and_release CONFIG+=tests CONFIG+=generator ^
+        CONFIG-=debug_and_release_target ^
            "PYTHON_PATH=%pythonLocation%" ^
            "PYTHON_VERSION=${{ steps.versions.outputs.PYTHON_VERSION_SHORT }}" ^
            PythonQt.pro

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -103,7 +103,7 @@ jobs:
         uname -a; gcc --version | grep "gcc"; python3 --version; qmake --version
         echo ============================
         qmake -r PythonQt.pro CONFIG+=ccache CONFIG+=release CONFIG+=force_debug_info \
-        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=sanitize_address \
+        CONFIG+=sanitizer CONFIG+=sanitize_undefined CONFIG+=tests CONFIG+=sanitize_address \
         PYTHON_VERSION=$(python3 --version | cut -d " " -f 2 | cut -d "." -f1,2) \
         PYTHON_DIR=$(which python3 | xargs dirname | xargs dirname)
         make -j $(nproc)
@@ -117,7 +117,7 @@ jobs:
       run: |
         qmake -query
         python --version
-        qmake CONFIG+=release CONFIG-=debug_and_release CONFIG-=debug_and_release_target ^
+        qmake CONFIG+=release CONFIG-=debug_and_release CONFIG-=debug_and_release_target CONFIG+=tests ^
            "PYTHONQTALL_CONFIG=${{ matrix.pythonqtall-config }}" ^
            "PYTHON_PATH=%pythonLocation%" ^
            "PYTHON_VERSION=${{ steps.setenv.outputs.PYTHON_VERSION_SHORT }}" ^

--- a/PythonQt.pro
+++ b/PythonQt.pro
@@ -1,6 +1,18 @@
 TEMPLATE = subdirs
 
-SUBDIRS = generator src extensions tests examples
-tests.depends += src extensions
+SUBDIRS = src extensions
 extensions.depends += src
-examples.depends += src extensions
+
+CONFIG(tests) {
+    SUBDIRS += tests
+    tests.depends += extensions
+}
+
+CONFIG(generator) {
+    SUBDIRS += generator
+}
+
+CONFIG(examples) {
+    SUBDIRS += examples
+    examples.depends += extensions
+}

--- a/build/python.prf
+++ b/build/python.prf
@@ -5,9 +5,6 @@
 isEmpty( PYTHON_VERSION ) {
   PYTHON_VERSION=$$(PYTHON_VERSION)
 }
-isEmpty( PYTHON_VERSION ) {
-  PYTHON_VERSION=3.10
-}
 
 isEmpty( PYTHON_DIR ) {
   PYTHON_DIR=$$(PYTHON_DIR)
@@ -15,6 +12,11 @@ isEmpty( PYTHON_DIR ) {
 !isEmpty( PYTHON_DIR ) {
   PYTHON_DIR=$${PYTHON_DIR}/
 }
+
+isEmpty( PYTHON_VERSION ) {
+  error(Missing PYTHON_VERSION)
+}
+
 
 PYTHON_VERSION_MAJOR=$$section(PYTHON_VERSION, ., 0, 0)
 PYTHON_VERSION_MINOR=$$section(PYTHON_VERSION, ., 1, 1)
@@ -42,7 +44,17 @@ contains(PKGCONFIG, "python.*"){
 # This can help with GNU/Linux (including macOS with Homebrew), MSYS2/MinGW environment,
 # and also with OpenEmbedded and other cross-builds
   CONFIG += link_pkgconfig
-  PYTHON_PKGCONFIG = $$member($$unique($$find(PKGCONFIG, "python.*")), 1, 1)
+  PYTHON_PKGCONFIG = $$unique(PKGCONFIG)
+  PYTHON_PKGCONFIG = $$find(PYTHON_PKGCONFIG, "python.*")
+  PYTHON_PKGCONFIG = $$member(PYTHON_PKGCONFIG)
+  !system($$pkgConfigExecutable() --modversion $$PYTHON_PKGCONFIG) {
+    message(PKGCONFIG is $$PKGCONFIG)
+    error(Bad or missing Python development package $$PYTHON_PKGCONFIG passed via PKGCONFIG argument)
+  }
+  PYTHON_VERSION_BY_PKGCONFIG = $$system($$pkgConfigExecutable() --modversion $$PYTHON_PKGCONFIG)
+  !equals(PYTHON_VERSION, $$PYTHON_VERSION_BY_PKGCONFIG):error(PYTHON_VERSION $$PYTHON_VERSION \
+         must be equal to the corresponding one from PKGCONFIG $$PYTHON_VERSION_BY_PKGCONFIG)
+
   # add rpath
   PYTHON_LIBDIR = $$system($$pkgConfigExecutable() --libs-only-L $$PYTHON_PKGCONFIG)
   QMAKE_RPATHDIR += $$replace(PYTHON_LIBDIR,-L,)

--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.pro
@@ -77,94 +77,45 @@ headers.path = $${INSTALL_PREFIX}/include
 INSTALLS += target headers
 
 defineTest(Xinclude) {
-  f=$$PYTHONQT_GENERATED_PATH/$$1/$${1}.pri
-  exists($$f):include($$f):export(HEADERS):export(SOURCES):export(DEFINES)
-
+  exists($$f) {
+    DEFINES += $$2 # shoud be in the included (generated) .pri file
+    QT += $$3 # shoud be in the included (generated) .pri file
+    include($$f)
+    export(HEADERS)
+    export(SOURCES)
+    export(DEFINES)
+    export(QT)
+    return(true)
+  }
+  return(false)
 }
 
+PythonQtCore:Xinclude(com_trolltech_qt_core, PYTHONQT_WITH_CORE, core)
 
-PythonQtCore {
-  DEFINES += PYTHONQT_WITH_CORE
-  Xinclude (com_trolltech_qt_core)
-  QT += core
-}
+PythonQtGui:Xinclude(com_trolltech_qt_gui, PYTHONQT_WITH_GUI, gui widgets printsupport)
 
-PythonQtGui  {
-  DEFINES += PYTHONQT_WITH_GUI
-  Xinclude (com_trolltech_qt_gui)
-  QT += gui widgets printsupport
-}
-
-PythonQtSvg {
-  DEFINES += PYTHONQT_WITH_SVG
-  Xinclude (com_trolltech_qt_svg)
-  QT += svg
+PythonQtSvg:Xinclude(com_trolltech_qt_svg, PYTHONQT_WITH_SVG, svg) {
   !lessThan(QT_MAJOR_VERSION,6): QT += svgwidgets
 }
 
-PythonQtSql {
-  DEFINES += PYTHONQT_WITH_SQL
-  Xinclude (com_trolltech_qt_sql)
-  QT += sql
-}
+PythonQtSql:Xinclude(com_trolltech_qt_sql, PYTHONQT_WITH_SQL, sql)
 
-PythonQtNetwork {
-  DEFINES += PYTHONQT_WITH_NETWORK
-  Xinclude (com_trolltech_qt_network)
-  QT += network
-}
+PythonQtNetwork:Xinclude(com_trolltech_qt_network, PYTHONQT_WITH_NETWORK, network)
 
-PythonQtOpengl {
-  DEFINES += PYTHONQT_WITH_OPENGL
-  QT += opengl
-  PythonQtCore: Xinclude (com_trolltech_qt_opengl)
-  QT += xml
-}
+PythonQtOpengl:Xinclude(com_trolltech_qt_opengl, PYTHONQT_WITH_OPENGL, opengl xml)
 
-PythonQtXml {
-  DEFINES += PYTHONQT_WITH_XML
-  Xinclude (com_trolltech_qt_xml)
-  QT += xml
-}
+PythonQtXml:Xinclude(com_trolltech_qt_xml, PYTHONQT_WITH_XML, xml)
 
-PythonQtXmlpatterns {
-  DEFINES += PYTHONQT_WITH_XMLPATTERNS
-  Xinclude (com_trolltech_qt_xmlpatterns)
-  QT += xmlpatterns
-}
+PythonQtXmlpatterns:Xinclude(com_trolltech_qt_xmlpatterns, PYTHONQT_WITH_XMLPATTERNS, xmlpatterns)
 
-PythonQtMultimedia {
-  DEFINES += PYTHONQT_WITH_MULTIMEDIA
-  Xinclude (com_trolltech_qt_multimedia)
-  QT += multimedia multimediawidgets
-}
+PythonQtMultimedia:Xinclude(com_trolltech_qt_multimedia, PYTHONQT_WITH_MULTIMEDIA, multimedia multimediawidgets)
 
-PythonQtQml {
-  DEFINES += PYTHONQT_WITH_QML
-  Xinclude (com_trolltech_qt_qml)
-  QT += qml
-}
+PythonQtQml:Xinclude(com_trolltech_qt_qml, PYTHONQT_WITH_QML, qml)
 
-PythonQtQuick {
-  DEFINES += PYTHONQT_WITH_QUICK
-  Xinclude (com_trolltech_qt_quick)
-  QT += quick quickwidgets
-}
+PythonQtQuick:Xinclude(com_trolltech_qt_quick, PYTHONQT_WITH_QUICK, quick quickwidgets)
 
-PythonQtUiTools {
-  DEFINES += PYTHONQT_WITH_UITOOLS
-  Xinclude (com_trolltech_qt_uitools)
-  QT += uitools
-}
+PythonQtUiTools:Xinclude(com_trolltech_qt_uitools, PYTHONQT_WITH_UITOOLS, uitools)
 
-PythonQtWebEngineWidgets {
-  DEFINES += PYTHONQT_WITH_WEBENGINEWIDGETS
-  Xinclude (com_trolltech_qt_webenginewidgets)
-  QT += webenginewidgets
-}
+PythonQtWebEngineWidgets:Xinclude(com_trolltech_qt_webenginewidgets, PYTHONQT_WITH_WEBENGINEWIDGETS, webenginewidgets)
 
-PythonQtWebKit {
-  DEFINES += PYTHONQT_WITH_WEBKIT
-  Xinclude (com_trolltech_qt_webkit)
-  QT += webkit webkitwidgets
-}
+PythonQtWebKit:Xinclude(com_trolltech_qt_webkit, PYTHONQT_WITH_WEBKIT, webkit webkitwidgets)


### PR DESCRIPTION
Make the behavior more obvious:
1. Explicitly specify the `Python` version when building (otherwise throw an error instead of using the default version)
2. Add `CONFIG` for `tests`, `generator`, and `examples` for flexible building