### PR TITLE
ENH: Improve Qt include path resolution macOS

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -217,7 +217,20 @@ namespace
       QRegularExpression re("#define\\s+QTCORE_VERSION\\s+0x([0-9a-f]+)", QRegularExpression::CaseInsensitiveOption);
       for (const QString &includeDir: getIncludeDirectories(commandLineIncludes))
       {
-        QFileInfo fi(QDir(includeDir), "qtcoreversion.h");
+        std::list<std::string> candiate_paths;
+        candiate_paths.emplace_back("qtcoreversion.h");
+        candiate_paths.emplace_back("QtCore/qtcoreversion.h");
+        candiate_paths.emplace_back("QtCore.framework/Headers/qtcoreversion.h");
+        QFileInfo fi(QDir(includeDir), QString("qtcoreversion.h"));
+        for (const std::string &candidate : candiate_paths)
+        {
+          QFileInfo candidate_fi(QDir(includeDir), candidate.c_str());
+          if (candidate_fi.exists() && candidate_fi.isFile())
+          {
+              fi = candidate_fi;
+              break;
+          }
+        }
         if (fi.exists())
         {
           QString filePath = fi.absoluteFilePath();

--- a/generator/simplecpp/simplecpp.h
+++ b/generator/simplecpp/simplecpp.h
@@ -39,6 +39,9 @@
 #endif
 
 namespace simplecpp {
+
+    std::string get_apple_framework_relative_path(const std::string& header);
+
     /** C code standard */
     enum cstd_t { CUnknown=-1, C89, C99, C11, C17, C23 };
 


### PR DESCRIPTION
Add specific framework path handling

Refactor include directory parsing to support multiple candidate paths for headers and introduce macOS-specific logic for resolving framework-relative header paths. Enhance generator flexibility and robustness for cross-platform usage.

Push upstream fix via:
https://github.com/danmar/simplecpp/pull/448