### PR TITLE
COMP: Remove use of deprecated 'count()' function

### DIFF
--- a/generator/parser/name_compiler.cpp
+++ b/generator/parser/name_compiler.cpp
@@ -108,7 +108,7 @@ void NameCompiler::visitUnqualifiedName(UnqualifiedNameAST *node)
       // ### cleanup
       _M_name.last() += QLatin1String("<");
       visitNodes(this, node->template_arguments);
-      _M_name.last().truncate(_M_name.last().count() - 1); // remove the last ','
+      _M_name.last().truncate(_M_name.last().length() - 1); // remove the last ','
       _M_name.last() += QLatin1String(">");
     }
 


### PR DESCRIPTION
PythonQt/generator/parser/name_compiler.cpp:111:46: \
    warning: 'count' is deprecated: Use size() or length() instead.
    [-Wdeprecated-declarations]