### PR TITLE
vendor(simplecpp): Update simplecpp.{h,cpp} to master (538c5c4); was v1.2.0 (a853253)

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -155,7 +155,7 @@ namespace
       std::unique_ptr<simplecpp::TokenList> rawtokens(new simplecpp::TokenList(ba.constData(), ba.size(), files, {}, &outputList));
       rawtokens->removeComments();
       simplecpp::TokenList outputTokens(files);
-      std::map<std::string, simplecpp::TokenList*> filedata;
+      simplecpp::FileDataCache filedata;
       simplecpp::preprocess(outputTokens, *rawtokens, files, filedata, dui, &outputList);
       simplecpp::cleanup(filedata);
       rawtokens.reset();

--- a/generator/simplecpp/README.txt
+++ b/generator/simplecpp/README.txt
@@ -1,4 +1,4 @@
-This code is taken from https://github.com/danmar/simplecpp, version 1.2.0 (a853253)
+This code is taken from https://github.com/danmar/simplecpp, version post-1.5.2 (538c5c4)
 
 The code was released under the 0BSD license (see LICENSE file).
 

--- a/generator/simplecpp/simplecpp.h
+++ b/generator/simplecpp/simplecpp.h
@@ -6,13 +6,19 @@
 #ifndef simplecppH
 #define simplecppH
 
+#if defined(_WIN32) || defined(__CYGWIN__) || defined(__MINGW32__)
+#  define SIMPLECPP_WINDOWS
+#endif
+
 #include <cctype>
 #include <cstring>
 #include <iosfwd>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef _WIN32
@@ -27,8 +33,10 @@
 #  define SIMPLECPP_LIB
 #endif
 
-#if (__cplusplus < 201103L) && !defined(__APPLE__)
-#define nullptr NULL
+#ifdef SIMPLECPP_WINDOWS
+#  include <cstdint>
+#else
+#  include <sys/stat.h>
 #endif
 
 #if defined(_MSC_VER)
@@ -47,6 +55,7 @@ namespace simplecpp {
 
     typedef std::string TokenString;
     class Macro;
+    class FileDataCache;
 
     /**
      * Location in source code
@@ -100,12 +109,12 @@ namespace simplecpp {
     class SIMPLECPP_LIB Token {
     public:
         Token(const TokenString &s, const Location &loc, bool wsahead = false) :
-            whitespaceahead(wsahead), location(loc), previous(nullptr), next(nullptr), string(s) {
+            whitespaceahead(wsahead), location(loc), previous(nullptr), next(nullptr), nextcond(nullptr), string(s) {
             flags();
         }
 
         Token(const Token &tok) :
-            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), previous(nullptr), next(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
+            macro(tok.macro), op(tok.op), comment(tok.comment), name(tok.name), number(tok.number), whitespaceahead(tok.whitespaceahead), location(tok.location), previous(nullptr), next(nullptr), nextcond(nullptr), string(tok.string), mExpandedFrom(tok.mExpandedFrom) {
         }
 
         void flags() {
@@ -141,6 +150,7 @@ namespace simplecpp {
         Location location;
         Token *previous;
         Token *next;
+        mutable const Token *nextcond;
 
         const Token *previousSkipComments() const {
             const Token *tok = this->previous;
@@ -214,14 +224,10 @@ namespace simplecpp {
         /** generates a token list from the given filename parameter */
         TokenList(const std::string &filename, std::vector<std::string> &filenames, OutputList *outputList = nullptr);
         TokenList(const TokenList &other);
-#if __cplusplus >= 201103L
         TokenList(TokenList &&other);
-#endif
         ~TokenList();
         TokenList &operator=(const TokenList &other);
-#if __cplusplus >= 201103L
         TokenList &operator=(TokenList &&other);
-#endif
 
         void clear();
         bool empty() const {
@@ -347,9 +353,118 @@ namespace simplecpp {
         bool removeComments; /** remove comment tokens from included files */
     };
 
+    struct SIMPLECPP_LIB FileData {
+        /** The canonical filename associated with this data */
+        std::string filename;
+        /** The tokens associated with this file */
+        TokenList tokens;
+    };
+
+    class SIMPLECPP_LIB FileDataCache {
+    public:
+        FileDataCache() = default;
+
+        FileDataCache(const FileDataCache &) = delete;
+        FileDataCache(FileDataCache &&) = default;
+
+        FileDataCache &operator=(const FileDataCache &) = delete;
+        FileDataCache &operator=(FileDataCache &&) = default;
+
+        /** Get the cached data for a file, or load and then return it if it isn't cached.
+         *  returns the file data and true if the file was loaded, false if it was cached. */
+        std::pair<FileData *, bool> get(const std::string &sourcefile, const std::string &header, const DUI &dui, bool systemheader, std::vector<std::string> &filenames, OutputList *outputList);
+
+        void insert(FileData data) {
+            FileData *const newdata = new FileData(std::move(data));
+
+            mData.emplace_back(newdata);
+            mNameMap.emplace(newdata->filename, newdata);
+        }
+
+        void clear() {
+            mNameMap.clear();
+            mIdMap.clear();
+            mData.clear();
+        }
+
+        typedef std::vector<std::unique_ptr<FileData>> container_type;
+        typedef container_type::iterator iterator;
+        typedef container_type::const_iterator const_iterator;
+        typedef container_type::size_type size_type;
+
+        size_type size() const {
+            return mData.size();
+        }
+        iterator begin() {
+            return mData.begin();
+        }
+        iterator end() {
+            return mData.end();
+        }
+        const_iterator begin() const {
+            return mData.begin();
+        }
+        const_iterator end() const {
+            return mData.end();
+        }
+        const_iterator cbegin() const {
+            return mData.cbegin();
+        }
+        const_iterator cend() const {
+            return mData.cend();
+        }
+
+    private:
+        struct FileID {
+#ifdef SIMPLECPP_WINDOWS
+            struct {
+                std::uint64_t VolumeSerialNumber;
+                struct {
+                    std::uint64_t IdentifierHi;
+                    std::uint64_t IdentifierLo;
+                } FileId;
+            } fileIdInfo;
+
+            bool operator==(const FileID &that) const noexcept {
+                return fileIdInfo.VolumeSerialNumber == that.fileIdInfo.VolumeSerialNumber &&
+                       fileIdInfo.FileId.IdentifierHi == that.fileIdInfo.FileId.IdentifierHi &&
+                       fileIdInfo.FileId.IdentifierLo == that.fileIdInfo.FileId.IdentifierLo;
+            }
+#else
+            dev_t dev;
+            ino_t ino;
+
+            bool operator==(const FileID& that) const noexcept {
+                return dev == that.dev && ino == that.ino;
+            }
+#endif
+            struct Hasher {
+                std::size_t operator()(const FileID &id) const {
+#ifdef SIMPLECPP_WINDOWS
+                    return static_cast<std::size_t>(id.fileIdInfo.FileId.IdentifierHi ^ id.fileIdInfo.FileId.IdentifierLo ^
+                                                    id.fileIdInfo.VolumeSerialNumber);
+#else
+                    return static_cast<std::size_t>(id.dev) ^ static_cast<std::size_t>(id.ino);
+#endif
+                }
+            };
+        };
+
+        using name_map_type = std::unordered_map<std::string, FileData *>;
+        using id_map_type = std::unordered_map<FileID, FileData *, FileID::Hasher>;
+
+        static bool getFileId(const std::string &path, FileID &id);
+
+        std::pair<FileData *, bool> tryload(name_map_type::iterator &name_it, const DUI &dui, std::vector<std::string> &filenames, OutputList *outputList);
+
+        container_type mData;
+        name_map_type mNameMap;
+        id_map_type mIdMap;
+    };
+
     SIMPLECPP_LIB long long characterLiteralToLL(const std::string& str);
 
-    SIMPLECPP_LIB std::map<std::string, TokenList*> load(const TokenList &rawtokens, std::vector<std::string> &filenames, const DUI &dui, OutputList *outputList = nullptr);
+    SIMPLECPP_LIB FileDataCache load(const TokenList &rawtokens, std::vector<std::string> &filenames, const DUI &dui, OutputList *outputList = nullptr, FileDataCache cache = {});
 
     /**
      * Preprocess
@@ -357,18 +472,18 @@ namespace simplecpp {
      * @param output TokenList that receives the preprocessing output
      * @param rawtokens Raw tokenlist for top sourcefile
      * @param files internal data of simplecpp
-     * @param filedata output from simplecpp::load()
+     * @param cache output from simplecpp::load()
      * @param dui defines, undefs, and include paths
      * @param outputList output: list that will receive output messages
      * @param macroUsage output: macro usage
      * @param ifCond output: #if/#elif expressions
      */
-    SIMPLECPP_LIB void preprocess(TokenList &output, const TokenList &rawtokens, std::vector<std::string> &files, std::map<std::string, TokenList*> &filedata, const DUI &dui, OutputList *outputList = nullptr, std::list<MacroUsage> *macroUsage = nullptr, std::list<IfCond> *ifCond = nullptr);
+    SIMPLECPP_LIB void preprocess(TokenList &output, const TokenList &rawtokens, std::vector<std::string> &files, FileDataCache &cache, const DUI &dui, OutputList *outputList = nullptr, std::list<MacroUsage> *macroUsage = nullptr, std::list<IfCond> *ifCond = nullptr);
 
     /**
      * Deallocate data
      */
-    SIMPLECPP_LIB void cleanup(std::map<std::string, TokenList*> &filedata);
+    SIMPLECPP_LIB void cleanup(FileDataCache &cache);
 
     /** Simplify path */
     SIMPLECPP_LIB std::string simplifyPath(std::string path);
@@ -393,10 +508,6 @@ namespace simplecpp {
 
 #if defined(_MSC_VER)
 #  pragma warning(pop)
-#endif
-
-#if (__cplusplus < 201103L) && !defined(__APPLE__)
-#undef nullptr
 #endif
 
 #endif


### PR DESCRIPTION
This pull request updates `simplecpp` anticipating the integration of changes intended to improve the generation of wrapper on macOS:
* https://github.com/danmar/simplecpp/pull/511

It also update the declaration of `filedata` variable in `main.cpp` to account for the introduction of `simplecpp::FileDataCache` structure through https://github.com/danmar/simplecpp/commit/a0430f34e8b9e8a5980158eb9c7e5101b9f19473 (previously it was declared as `std::map<std::string, TokenList*>`)

---

Upstream: danmar/simplecpp@538c5c4
Source date: 2025-08-23
Files:

  ```
  generator/simplecpp/simplecpp.h
  generator/simplecpp/simplecpp.cpp
  ```

Patch: `generator/simplecpp/do_not_stop_on_error.patch` re-applied

Compare: https://github.com/danmar/simplecpp/compare/a853253...538c5c4

---

List of simplecpp changes:

```
$ git shortlog --no-merges a853253..538c5c4 -- simplecpp.*
Daniel Marjamäki (6):
      Fix #403 (Stack overflow in Macro::expand()) (#411)
      Fix #409 (fuzzing crash in simplecpp::Macro::expandToken()) (#412)
      Revert "fix: use both absolute and relative header paths in header matching (#362)" (#415)
      Revert "Fix #404: simplecpp::TokenList::constFold does not fold '( 0 ) && 10 < X' properly (#405)" (#416)
      Fix #446 (change the rules of relativeness preserving to depend on the source file including it for relative path includes) (#445)
      Fix #471 (preserve line splicing information in '// ..' comments) (#472)

Ludvig Gunne Lindström (3):
      Fix #454: Accept __has_include for GNU C standards (#456)
      Fix #452: Undefined function-style macro does not cause an error (#453)
      fix #459: Set __STRICT_ANSI__=1 for non-gnu standards (#460)

Oliver Stöneberg (1):
      simplecpp.cpp: fixed Visual Studio C4800 compiler warnings (#481)

Tal500 (4):
      fix: use both absolute and relative header paths in header matching (#362)
      Fix relative paths, again (#418)
      Preserve relativeness of included paths (w.r.t. current directory) (#428)
      fix: parent relative paths, and rework on the whole path extraction mechanics (#429)

clock999 (1):
      fix #337 - line splicing in comment not handled properly (#431)

glankk (8):
      Fix #381 (When there are header files with the same name, the correct file cannot be found) (#443)
      Fix #368 (__VA_OPT__ is not handled good enough) (#451)
      Fix #449 (Update c++ standard to c++11) (#450)
      Add caching of conditional directive chains (#468)
      Include and path handling optimization (#447)
      Fix #391 (`__TIME__` replacement might be empty depending on compiler) (#441)
      Remove execute bit from simplecpp.cpp/h (#494)
      Fix infinite loop with circular includes (#497)

olabetskyi (1):
      Fix #404: simplecpp::TokenList::constFold does not fold '( 0 ) && 10 < X' properly (#405)
```