### PR TITLE
CI: Qt 6.9 on macos & windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,10 @@ jobs:
            python-version: '3.11'
            qt-version: '5.12.*'
            configuration: 'debug'
+         - macos-version: 'latest'
+           python-version: '3.11'
+           qt-version: '6.9.*'
+           configuration: 'debug'
     runs-on: macos-${{ matrix.macos-version }}
     steps:
     - name: Install Qt
@@ -269,6 +273,12 @@ jobs:
            python-version: '3.13'
            python-arch: 'x64'
            qt-version: '5.15.*'
+           pythonqtall-config: 'PythonQtCore PythonQtGui PythonQtMultimedia'
+
+         - qt-arch: 'win64_msvc2019_64'
+           python-version: '3.13'
+           python-arch: 'x64'
+           qt-version: '6.9.*'
            pythonqtall-config: 'PythonQtCore PythonQtGui PythonQtMultimedia'
 
          - qt-arch: 'win32_mingw53'


### PR DESCRIPTION
Hi,

I am trying to build pythonqt for Qt6 on linux and macos to [update the package on nixpkgs](https://github.com/NixOS/nixpkgs/pull/437521), but I am not able to generate the cpp on macos.

This issue can already be seen in the current CI: 
https://github.com/MeVisLab/pythonqt/actions/runs/16336586053/job/46149827921 :
```
Run cd generator
Please wait while source files are being generated...
Parsing typesystem file [:/trolltech/generator/build_all.txt]
"is not set. " Assuming standard binary install using frameworks.
WARNING(Generate) :: ShellImplGenerator: no java classes, skipping
WARNING(Generate) :: ShellHeaderGenerator: no java classes, skipping
PreProcessing - Generate [.preprocessed.tmp] using [:/trolltech/generator/qtscript_masterinclude.h] and include-paths [/Users/runner/work/pythonqt/Qt/5.9.9/clang_64/lib]
Building model using [.preprocessed.tmp]
Classes in typesystem: 0
Generated:
  - header....: 0 (0)
  - impl......: 0 (0)
  - modules...: 0 (0)
  - pri.......: 0 (0)

Done, 2 warnings (1851 known issues)
0s
Run actions/upload-artifact@v4
Warning: No files were found with the provided path: generated_cpp. No artifacts will be uploaded.
```

But this does not trigger any failure, so I guess this was not seen.

So this PR add some jobs for macos and windows on Qt6, which should show those failures more explicitly