### PR TITLE
Fixed: When generating wrappers for non-Qt code, includes lost their directories

### DIFF
--- a/generator/abstractmetabuilder.h
+++ b/generator/abstractmetabuilder.h
@@ -78,6 +78,9 @@ public:
     QString fileName() const { return m_file_name; }
     void setFileName(const QString &fileName) { m_file_name = fileName; }
 
+    //! Set list of include directories. This will be used to make absolute include paths relative.
+    void setIncludePaths(const QStringList& includePaths) { m_include_paths = includePaths; }
+
     void dumpLog();
 
     bool build();
@@ -153,7 +156,11 @@ private:
 
     AbstractMetaClass* getGlobalNamespace(const TypeEntry* typeEntry);
 
+    // turn absolute file path into a relative include
+    Include getRelativeInclude(const QString& path);
+
     QString m_file_name;
+    QStringList m_include_paths;
 
     AbstractMetaClassList m_meta_classes;
     QHash<QString,AbstractMetaClass*> m_templates;

--- a/generator/generatorset.h
+++ b/generator/generatorset.h
@@ -58,6 +58,7 @@ class GeneratorSet : public QObject
     virtual bool readParameters(const QMap<QString, QString> args) = 0;
     virtual void buildModel(const QString pp_file) = 0;
     virtual void dumpObjectTree() = 0;
+    virtual void setIncludePaths(const QStringList& includePaths) = 0;
     virtual QString generate() = 0;
 
     static GeneratorSet *getInstance();

--- a/generator/generatorsetqtscript.cpp
+++ b/generator/generatorsetqtscript.cpp
@@ -85,6 +85,11 @@ void GeneratorSetQtScript::dumpObjectTree() {
  
 }
 
+void GeneratorSetQtScript::setIncludePaths(const QStringList& includePaths)
+{
+    builder.setIncludePaths(includePaths);
+}
+
 QString GeneratorSetQtScript::generate() {
     AbstractMetaClassList classes = builder.classesTopologicalSorted();
     QSet<QString> declaredTypeNames = builder.qtMetaTypeDeclaredTypeNames();

--- a/generator/generatorsetqtscript.h
+++ b/generator/generatorsetqtscript.h
@@ -52,13 +52,14 @@ class GeneratorSetQtScript : public GeneratorSet
 public:
     GeneratorSetQtScript();
 
-    QString usage();
-    bool readParameters(const QMap<QString, QString> args);
+    QString usage() override;
+    bool readParameters(const QMap<QString, QString> args) override;
 
-    void buildModel(const QString pp_file);
-    void dumpObjectTree();
+    void buildModel(const QString pp_file) override;
+    void dumpObjectTree() override;
+    void setIncludePaths(const QStringList& includePaths) override;
 
-    QString generate(                                       );
+    QString generate() override;
 
 private:
     MetaQtScriptBuilder builder;


### PR DESCRIPTION
The preprocessed file only contains absolute paths, so we have to reconstruct the relative path to be able to emit the correct includes.
