### PR TITLE
NumPy 2 defines its own "slots". 

### DIFF
--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -345,7 +345,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       }
     }
   }
-  s << "public slots:" << endl;
+  s << "public Q_SLOTS:" << endl;
   if (meta_class->generateShellClass() || !meta_class->isAbstract()) {
 
     bool copyConstructorSeen = false;


### PR DESCRIPTION
To avoid the collision, use Q_SLOTS instead