### PR TITLE
Re-introduce support for QMatrix when building against Qt < 6.0

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -260,6 +260,9 @@ void PythonQt::init(int flags, const QByteArray& pythonQtModuleName)
     PythonQtRegisterToolClassesTemplateConverterForKnownClass(QPen);
     PythonQtRegisterToolClassesTemplateConverterForKnownClass(QTextLength);
     PythonQtRegisterToolClassesTemplateConverterForKnownClass(QTextFormat);
+#if QT_VERSION < 0x060000
+    PythonQtRegisterToolClassesTemplateConverterForKnownClass(QMatrix);
+#endif
 
     PyObject* pack = PythonQt::priv()->packageByName("QtCore");
     PyObject* pack2 = PythonQt::priv()->packageByName("Qt");

--- a/src/PythonQtVariants.h
+++ b/src/PythonQtVariants.h
@@ -72,6 +72,9 @@
 #include <QPen>
 #include <QTextLength>
 #include <QTextFormat>
+#if QT_VERSION < 0x060000
+#include <QMatrix>
+#endif
 
 #endif
 


### PR DESCRIPTION
This partially reverts 10a3e499 ("Qt6 compatibility fixes for core PythonQt library", 2023-08-21)

(cherry picked from commit commontk/PythonQt@b2156e9b1b61d35fb3ef19fd5aadeb2246cf9ff8)