### PR TITLE
Fix warning related to use of qrand() when building against Qt 5.15

### DIFF
--- a/src/PythonQtStdDecorators.h
+++ b/src/PythonQtStdDecorators.h
@@ -58,7 +58,7 @@
 #include <QMetaMethod>
 #include <QMetaEnum>
 #include <QMetaProperty>
-#if QT_VERSION >= 0x060000
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
 #include <QRandomGenerator>
 #endif
 
@@ -109,7 +109,7 @@ public Q_SLOTS:
 
   int static_Qt_qrand()
   {
-#if QT_VERSION < 0x060000
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
     return qrand();
 #else
     return QRandomGenerator::global()->generate();
@@ -118,7 +118,7 @@ public Q_SLOTS:
 
   void static_Qt_qsrand(uint a)
   {
-#if QT_VERSION < 0x060000
+#if (QT_VERSION < QT_VERSION_CHECK(5, 15, 0))
     qsrand(a);
 #else
     QRandomGenerator::global()->seed(a);


### PR DESCRIPTION
Starting with Qt 5.15, the `qrand` function has been deprecated in favor of `QRandomGenerator`. This change updates `PythonQtStdDecorators.h` to use `QRandomGenerator` when building against Qt 5.15 or later.

See qt/qtbase@b3c0e9afa ("Deprecate qrand/qsrand", 2001-09-17)

---

> [!NOTE]
> For reference, those patches were developed in the context of the `commontk/PythonQt` fork.
> 
> Cherry picked from commits commontk/PythonQt@c1579e2