### PR TITLE
fix: Address warnings with QSet::fromList in Qt 5.15

### DIFF
--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -562,7 +562,7 @@ QStringList PythonQtClassInfo::memberList()
     }
   }
 
-#if QT_VERSION >= 0x060000
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
   QSet<QString> set(l.begin(), l.end());
   return set.values();
 #else

--- a/src/PythonQtClassWrapper.cpp
+++ b/src/PythonQtClassWrapper.cpp
@@ -477,7 +477,7 @@ static PyObject *PythonQtClassWrapper_getattro(PyObject *obj, PyObject *name)
 
     auto members = wrapper->classInfo()->memberList();
     auto properties = wrapper->classInfo()->propertyList();
-#if QT_VERSION >= 0x060000
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
     QSet<QString> completeSet(members.begin(), members.end());
     completeSet.unite(QSet<QString>(properties.begin(), properties.end()));
 #else


### PR DESCRIPTION
Starting with Qt 5.15, the conversion functions between QList and QSet (e.g., `QSet::fromList`) have been deprecated in favor of range constructors.

This change updates the code to use the new range constructors to avoid deprecation warnings starting from Qt 5.14 (instead of Qt 6)

Related upstream Qt commits:
* qt/qtbase@92f984273 ("Deprecate conversion functions between QList and QSet", 2019-05-07)
* qt/qtbase@e59e5643b ("Use QT_DEPRECATED_X instead of Q_DECL_DEPRECATED_X", 2020-02-25)

---

> [!NOTE]
> For reference, those patches were developed in the context of the `commontk/PythonQt` fork.
> 
> Cherry picked from commits commontk/PythonQt@630e37667
