### PR TITLE
Replace NULL with nullptr

### DIFF
--- a/src/PythonQtSlot.cpp
+++ b/src/PythonQtSlot.cpp
@@ -613,7 +613,7 @@ meth_get__self__(PythonQtSlotFunctionObject *m, void * /*closure*/)
   if (PyEval_GetRestricted()) {
     PyErr_SetString(PyExc_RuntimeError,
       "method.__self__ not accessible in restricted mode");
-    return NULL;
+    return nullptr;
   }
 #endif
   self = m->m_self;


### PR DESCRIPTION
Follow-up of c00ebf4d ("Replace NULL with nullptr", 2023-01-01)

---

> [!NOTE]
> For reference, those patches were developed in the context of the `commontk/PythonQt` fork.
> 
> Cherry picked from commits commontk/PythonQt@5d2c9b6f1