### PR TITLE
addDecorators: Check for null object

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1560,6 +1560,10 @@ PythonQtClassInfo* PythonQtPrivate::currentClassInfoForClassWrapperCreation()
 
 void PythonQtPrivate::addDecorators(QObject* o, int decoTypes)
 {
+  if (o == nullptr)
+    {
+    return;
+    }
   o->setParent(this);
   int numMethods = o->metaObject()->methodCount();
   for (int i = 0; i < numMethods; i++) {


### PR DESCRIPTION
This prevents potential crashes or undefined behavior when a null object is passed to the method.

---

> [!NOTE]
> For reference, those patches were developed in the context of the `commontk/PythonQt` fork.
> 
> Cherry picked from commits commontk/PythonQt@751ec46a3