### PR TITLE
fix(windows): Support MSVC Debug build linking against Release Python

### DIFF
--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -72,7 +72,7 @@
 // release Python DLL if it is available by undefining _DEBUG while
 // including Python.h
 #if defined(PYTHONQT_USE_RELEASE_PYTHON_FALLBACK) && defined(_DEBUG)
-#undef _DEBUG
+# define PYTHONQT_UNDEF_DEBUG
 // Include these low level headers before undefing _DEBUG. Otherwise when doing
 // a debug build against a release build of python the compiler will end up
 // including these low level headers without DEBUG enabled, causing it to try
@@ -92,14 +92,17 @@
 # include <sys/stat.h>
 # include <time.h>
 # include <wchar.h>
-#if defined(_MSC_VER) && _MSC_VER >= 1400
-#define _CRT_NOFORCE_MANIFEST 1
-#define _STL_NOFORCE_MANIFEST 1
+# undef _DEBUG
+# if defined(_MSC_VER) && _MSC_VER >= 1400
+#  define _CRT_NOFORCE_MANIFEST 1
+#  define _STL_NOFORCE_MANIFEST 1
+# endif
 #endif
+
 #include <Python.h>
-#define _DEBUG
-#else
-#include <Python.h>
+
+#ifdef PYTHONQT_UNDEF_DEBUG
+# define _DEBUG
 #endif
 
 // By including Python.h on Linux truncate could have been defined (in unistd.h)


### PR DESCRIPTION
This PR fixes Windows/MSVC build and link issues when **PythonQt is built in Debug** while **linking against a Release Python** (e.g., only `pythonXY.dll`/`pythonXY.lib` are available).

**Summary:**

* Adopt the strategy used in VTK to temporarily undefine `_DEBUG` only for the `Python.h` inclusion, while:

  * **Pre-including low-level CRT headers** *before* undefining `_DEBUG` to avoid pulling in release-mode CRT variants inadvertently.
  * Defining `_CRT_NOFORCE_MANIFEST` and `_STL_NOFORCE_MANIFEST` on MSVC ≥ 1400 to prevent inconsistent CRT manifest flags.
  * Restoring `_DEBUG` afterward to keep the rest of the TU in the correct debug configuration.

* Wrap the behavior with a small guard macro:

  * Introduce `PYTHONQT_UNDEF_DEBUG` so we can safely re-define `_DEBUG` only when we actually changed it.

* All changes are conditioned on `PYTHONQT_USE_RELEASE_PYTHON_FALLBACK && _DEBUG`.

**Motivation:**

Without these adjustments, MSVC may:

* Emit CRT manifest inconsistencies (e.g., `_CRT_MANIFEST_DEBUG`, `_CRT_MANIFEST_RETAIL`, `_CRT_MANIFEST_INCONSISTENT`) across the same Translation Unit.
* Trigger link errors such as `_invalid_parameter_noinfo_noreturn` due to mismatched debug/release CRT resolution caused by including system headers with the wrong `_DEBUG` state.

**References:**

* Mirrors the approach in VTK: https://github.com/Kitware/VTK/commit/81d4a72c1195437403f1772559c9c28978818f03
* Originally introduced via commontk/PythonQt@8a50eaa6 and refined in commontk/PythonQt@77d8177.
* Original issue: commontk/PythonQt#9 (thanks @Neosettler).