### PR TITLE
Fix compilation issues on macOS by conditionally undefining ctype macros

### DIFF
--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -142,20 +142,11 @@
 #define PyBytes_FromStringAndSize PyString_FromStringAndSize
 #endif
 
-/*
- * The following undefs for C standard library macros prevent
- * build errors of the following type on macOS 10.7.4 and XCode 4.3.3
- *
-/usr/include/c++/4.2.1/bits/localefwd.h:57:21: error: too many arguments provided to function-like macro invocation
-    isspace(_CharT, const locale&);
-                    ^
-/usr/include/c++/4.2.1/bits/localefwd.h:56:5: error: 'inline' can only appear on functions
-    inline bool
-    ^
-/usr/include/c++/4.2.1/bits/localefwd.h:57:5: error: variable 'isspace' declared as a template
-    isspace(_CharT, const locale&);
-    ^
-*/
+// Avoid clashes with libstdc++ <locale> by undefining ctype macros
+// that CPython may introduce on macOS when the UTF-8 ctype quirk is enabled.
+// (_PY_PORT_CTYPE_UTF8_ISSUE is defined by CPython’s pyport.h; we apply these
+// undefs only in C++ builds.)
+#if defined(_PY_PORT_CTYPE_UTF8_ISSUE) && defined(__cplusplus)
 #undef isalnum
 #undef isalpha
 #undef islower
@@ -163,6 +154,7 @@
 #undef isupper
 #undef tolower
 #undef toupper
+#endif
 
 #endif
 

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -142,4 +142,27 @@
 #define PyBytes_FromStringAndSize PyString_FromStringAndSize
 #endif
 
+/*
+ * The following undefs for C standard library macros prevent
+ * build errors of the following type on macOS 10.7.4 and XCode 4.3.3
+ *
+/usr/include/c++/4.2.1/bits/localefwd.h:57:21: error: too many arguments provided to function-like macro invocation
+    isspace(_CharT, const locale&);
+                    ^
+/usr/include/c++/4.2.1/bits/localefwd.h:56:5: error: 'inline' can only appear on functions
+    inline bool
+    ^
+/usr/include/c++/4.2.1/bits/localefwd.h:57:5: error: variable 'isspace' declared as a template
+    isspace(_CharT, const locale&);
+    ^
+*/
+#undef isalnum
+#undef isalpha
+#undef islower
+#undef isspace
+#undef isupper
+#undef tolower
+#undef toupper
+
 #endif
+


### PR DESCRIPTION
This pull request addresses compilation issues on older macOS toolchains caused by ctype macros defined by `<Python.h>`. The changes include:

1. Undefining problematic ctype macros (`isalnum`, `isalpha`, `islower`, `isspace`, `isupper`, `tolower`, `toupper`) after including Python headers, to avoid clashes with C++ standard library headers like `<locale>`.
2. Restricting the undefinition of these macros to macOS C++ builds by checking for `_PY_PORT_CTYPE_UTF8_ISSUE` and `__cplusplus` macros.