### PR TITLE
Update main function signature to be consistent across generator, test and examples

### DIFF
--- a/examples/PyCPPWrapperExample/main.cpp
+++ b/examples/PyCPPWrapperExample/main.cpp
@@ -45,7 +45,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/examples/PyCustomMetaTypeExample/main.cpp
+++ b/examples/PyCustomMetaTypeExample/main.cpp
@@ -45,7 +45,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/examples/PyDecoratorsExample/main.cpp
+++ b/examples/PyDecoratorsExample/main.cpp
@@ -45,7 +45,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/examples/PyGettingStarted/main.cpp
+++ b/examples/PyGettingStarted/main.cpp
@@ -47,7 +47,7 @@
 #include <QPushButton>
 #include <QLineEdit>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
   

--- a/examples/PyGuiExample/main.cpp
+++ b/examples/PyGuiExample/main.cpp
@@ -50,7 +50,7 @@
 #include <QLayout>
 
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/examples/PyLauncher/main.cpp
+++ b/examples/PyLauncher/main.cpp
@@ -48,7 +48,7 @@
 #include <QMessageBox>
 
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/examples/PyScriptingConsole/main.cpp
+++ b/examples/PyScriptingConsole/main.cpp
@@ -52,7 +52,7 @@
 #include <QLayout>
 
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 

--- a/src/PythonQtDoc.h
+++ b/src/PythonQtDoc.h
@@ -572,7 +572,7 @@ the python2x.[lib | dll | so | dynlib].
  #include <QApplication>
  ...
 
- int main( int argc, char **argv )
+ int main(int argc, char *argv[])
  {
 
   QApplication qapp(argc, argv);

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -45,7 +45,7 @@
 
 #include <QApplication>
 
-int main( int argc, char **argv )
+int main(int argc, char *argv[])
 {
   QApplication qapp(argc, argv);
 


### PR DESCRIPTION
The changes ensure that the main function signatures in the generator, test and example files is consistent.

It updates the `argv` parameter type from `char **argv` to `char *argv[]` and resolves a specific link error encountered when building `PythonQtCppTests` on Windows.

This will be helpful to integrate with the CMake/CTest testing framework. By default, the CMake test driver[^1] expects the main function to have the following signature:

```
typedef int (*MainFuncPointer)(int, char* []);
```

[^1]: https://github.com/Kitware/CMake/blob/master/Templates/TestDriver.cxx.in

This will fix link errors like the following when building `PythonQtCppTests` on Windows:

```
1>PythonQtCppTests.obj : error LNK2001: unresolved external symbol "int __cdecl tests_PythonQtTestMain(int,char * * const)" (?tests_PythonQtTestMain@@YAHHQEAPEAD@Z)
1>C:\temp\PythonQt-build\Debug\PythonQtCppTests.exe : fatal error LNK1120: 1 unresolved externals
```

---

> [!NOTE]
> For reference, those patches were developed in the context of the `commontk/PythonQt` fork.
> 
> Cherry picked from commit commontk/PythonQt@aa1a16f