### PR TITLE
Improve PythonQt test cleanup consistency and add alternative cleanup order test

### DIFF
--- a/tests/PythonQtTestCleanup.cpp
+++ b/tests/PythonQtTestCleanup.cpp
@@ -89,6 +89,15 @@ void PythonQtTestCleanup::testSignalReceiverCleanup()
     ));
 }
 
+void PythonQtTestCleanup::testPyFinalizeThenPythonQtCleanup()
+{
+  if (Py_IsInitialized()) {
+      Py_Finalize();
+  }
+
+  PythonQt::cleanup();
+}
+
 bool PythonQtTestCleanupHelper::runScript(const char* script)
 {
   _passed = false;

--- a/tests/PythonQtTestCleanup.h
+++ b/tests/PythonQtTestCleanup.h
@@ -20,6 +20,7 @@ private Q_SLOTS:
   void testCallQtMethodInDestructorOwnedQTimer();
   void testCallQtMethodInDestructorWeakRefGuarded();
   void testSignalReceiverCleanup();
+  void testPyFinalizeThenPythonQtCleanup();
 
 private:
   PythonQtTestCleanupHelper* _helper;


### PR DESCRIPTION
`PythonQtTestCleanup`:
* Adds a new test to check the behavior when Python is finalized before calling PythonQt cleanup.
* Consistently indent test case and use helper (`_helper->runScript`) everywhere

--- 

The addition of the test `PythonQtTestCleanup::testPyFinalizeThenPythonQtCleanup` seems to indicate that some of the changes proposed in the following pull request may not be needed:
* https://github.com/MeVisLab/pythonqt/pull/267

The new test also check that the cleanup order currently used in `CTK`[^1] (and by extension `Slicer`[^2]) works as expected.

[^1]: https://github.com/commontk/CTK/blob/833ae56e69d403bd0c83f2c331a32a8fd9c70285/Libs/Scripting/Python/Core/ctkAbstractPythonManager.cpp#L85-L92
[^2]: https://github.com/Slicer/Slicer/blob/b7ff98e7ce49d5f57ee67be3ee9b76dc03acbe95/Base/QTCore/qSlicerCorePythonManager.h