### PR TITLE
Fix warning about missing or non-existing QTDIR

### DIFF
--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -100,8 +100,8 @@ namespace
       QString qtdir = getenv("QTDIR");
       if (qtdir.isEmpty() || !QDir(qtdir).exists(qtdir))
       {
-        QString reason = "The QTDIR environment variable " + qtdir.isEmpty() ?
-                         "is not set. " : "points to a non-existing directory. ";
+	    QString reason = "The QTDIR environment variable " +
+			QString(qtdir.isEmpty() ? "is not set. " : "points to a non-existing directory. ");
 #if defined(Q_OS_MAC)
         qWarning() << reason << "Assuming standard binary install using frameworks.";
             QString frameworkDir = "/Library/Frameworks";


### PR DESCRIPTION
- missing parenthesis caused wrong warning output

The warning was always "is not set. " instead of "The QTDIR environment variable is not set. " or "The QTDIR environment variable points to a non-existing directory. "