### PR TITLE
Qt header discovery & framework support; vendor simplecpp update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,9 +257,8 @@ jobs:
       if: ${{ contains(matrix.configuration, 'release') }}
       run: |
         cd generator
-        # workaround to allow to find the Qt include dirs for installed standard qt packages
         UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
-        QTDIR=-UNDEFINED- ./pythonqt_generator --qt-version=${{ steps.versions.outputs.QT_VERSION_FULL }} --include-paths=$QT_ROOT_DIR/lib
+        ./pythonqt_generator
 
     - name: Upload Wrappers
       if: ${{ contains(matrix.configuration, 'release') }}
@@ -267,8 +266,7 @@ jobs:
       with:
         name: wrappers_macos${{ steps.versions.outputs.MACOS_VERSION_SHORT }}_qt${{ steps.versions.outputs.QT_VERSION_SHORT }}
         path: generated_cpp
-        # comment in after #276 is fixed
-        # if-no-files-found: error
+        if-no-files-found: error
 
   windows:
     strategy:

--- a/generator/main.cpp
+++ b/generator/main.cpp
@@ -306,13 +306,30 @@ namespace
     unsigned int getQtVersion(const QStringList& paths)
     {
       QRegularExpression re("#define\\s+QTCORE_VERSION\\s+0x([0-9a-f]+)", QRegularExpression::CaseInsensitiveOption);
+
+      // Iterate through provided paths to find the qtcoreversion.h header file
       for (const QString &path: paths)
       {
 #ifdef Q_OS_MACOS
-        QString qtCoreVersionHeader = joinPath(path, "Versions/A/Headers/qtcoreversion.h");
+        // Define potential locations for the header file on macOS
+        const QStringList candidates = {
+          joinPath(path, "Versions/A/Headers/qtcoreversion.h"),
+          joinPath(path, "Versions/5/Headers/qtcoreversion.h"),
+          joinPath(path, "Headers/qtcoreversion.h"), // top-level Headers (often a symlink into Versions)
+        };
 #else
-        QString qtCoreVersionHeader = joinPath(path, "qtcoreversion.h");
+        // Define the location for other platforms
+        const QStringList candidates = { joinPath(path, "qtcoreversion.h") };
 #endif
+        // Pick the first existing candidate
+        QString qtCoreVersionHeader;
+        for (const QString& candidate : candidates) {
+          if (QFile::exists(candidate)) {
+            qtCoreVersionHeader = candidate;
+            break;
+          }
+        }
+
         if (QFile::exists(qtCoreVersionHeader))
         {
           QString filePath = QFileInfo(qtCoreVersionHeader).absoluteFilePath();

--- a/generator/simplecpp/README.txt
+++ b/generator/simplecpp/README.txt
@@ -1,4 +1,9 @@
-This code is taken from https://github.com/danmar/simplecpp, version post-1.5.2 (37fa4f4)
+This code is taken from https://github.com/commontk/simplecpp, version post-1.5.2 (bfc53ad)
+
+Origin:
+
+* commontk/simplecpp is a fork of https://github.com/danmar/simplecpp
+* It corresponds to upstream commit 37fa4f4, with PR #511 (https://github.com/danmar/simplecpp/pull/511) backported.
 
 The code was released under the 0BSD license (see LICENSE file).
 

--- a/generator/simplecpp/simplecpp.h
+++ b/generator/simplecpp/simplecpp.h
@@ -395,13 +395,70 @@ namespace simplecpp {
 
     /**
      * Command line preprocessor settings.
-     * On the command line these are configured by -D, -U, -I, --include, -std
+     *
+     * Mirrors typical compiler options:
+     *   -D <name>=<value>       Add macro definition
+     *   -U <name>               Undefine macro
+     *   -I <dir>                Add include search directory
+     *   -isystem <dir>          Add system include search directory
+     *   -F <dir>                Add framework search directory (Darwin)
+     *   -iframework <dir>       Add system framework search directory (Darwin)
+     *   --include <file>        Force inclusion of a header
+     *   -std=<version>          Select language standard (C++17, C23, etc.)
+     *
+     * Path search behavior:
+     *   - If searchPaths is non-empty, it is used directly, preserving the
+     *     left-to-right order and distinguishing between Include, Framework,
+     *     and SystemFramework kinds.
+     *   - If searchPaths is empty, legacy includePaths is used instead, and
+     *     each entry is treated as a normal Include path (for backward
+     *     compatibility).
      */
     struct SIMPLECPP_LIB DUI {
         DUI() : clearIncludeCache(false), removeComments(false) {}
+
+        // Typed search path entry. Mirrors GCC behavior for -I, -isystem, -F, -iframework.
+        enum class PathKind { Include, SystemInclude, Framework, SystemFramework };
+        struct SearchPath {
+            std::string path;
+            PathKind kind;
+        };
+
+        /**
+         *  Mirrors compiler option -I<dir>
+         *
+         *  If 'legacy' is true, the path is added to the 'includePaths' vector;
+         *  otherwise, it is added to 'searchPaths' with 'PathKind::Include'.
+         */
+        void addIncludePath(const std::string& path, bool legacy=false) {
+            if (legacy) {
+                includePaths.push_back(path);
+            } else {
+                searchPaths.push_back({path, PathKind::Include});
+            }
+        }
+        /** Mirrors compiler option -I<dir> */
+        void addSystemIncludePath(const std::string& path) {
+            searchPaths.push_back({path, PathKind::SystemInclude});
+        }
+        /** Mirrors compiler option -F<dir> */
+        void addFrameworkPath(const std::string& path) {
+            searchPaths.push_back({path, PathKind::Framework});
+        }
+        /** Mirrors compiler option -iframework<dir> */
+        void addSystemFrameworkPath(const std::string& path) {
+            searchPaths.push_back({path, PathKind::SystemFramework});
+        }
+
         std::list<std::string> defines;
         std::set<std::string> undefined;
+
+        // Back-compat: legacy -I list. If searchPaths is empty at use time,
+        // consumers should mirror includePaths -> searchPaths as Include.
         std::list<std::string> includePaths;
+        // New: ordered, interleaved search paths with kind.
+        std::vector<SearchPath> searchPaths;
+
         std::list<std::string> includes;
         std::string std;
         bool clearIncludeCache;


### PR DESCRIPTION
This PR modernizes how the generator discovers Qt headers/frameworks and vendors a newer `simplecpp` with framework-aware search logic. Together these changes make builds robust on macOS (Qt frameworks) and cleaner across all platforms.

## Vendor `simplecpp` update

* Bumps `generator/simplecpp/{simplecpp.h, simplecpp.cpp}` to **patched-2025-08-30-37fa4f49b** (upstream: commontk/simplecpp@bfc53ad; previously danmar/simplecpp@37fa4f4).
* Re-applies local patch: `generator/simplecpp/do_not_stop_on_error.patch`.
* Introduces a typed, ordered search path API:

  * `DUI::PathKind { Include, SystemInclude, Framework, SystemFramework }`
  * `DUI::searchPaths` plus helpers `addIncludePath`, `addSystemIncludePath`, `addFrameworkPath`, `addSystemFrameworkPath`
  * Back-compat: if `searchPaths` is empty, legacy `includePaths` is mirrored as `Include`.
* Adds Apple framework resolution for `#include <Pkg/Hdr.h>` → `<Pkg.framework/Headers/Hdr.h>` (and `PrivateHeaders` fallback).
* Interleaves `-I` and `-F` in the original CLI order; handles `-isystem` and `-iframework`.

**Upstream compare:** [https://github.com/commontk/simplecpp/compare/37fa4f4...bfc53ad](https://github.com/commontk/simplecpp/compare/37fa4f4...bfc53ad)

> [!NOTE]
> This changes are vendored from the `commontk/simplecpp` fork including commit backported from:
> * https://github.com/danmar/simplecpp/pull/511

## Generator: discover Qt headers via `QLibraryInfo`

* Prefers `QLibraryInfo::HeadersPath`; falls back to `$QTDIR/include` if needed.
* Accepts include roots from:

  * `PYTHONQT_INCLUDE` (path list; validated)
  * `--include-paths` (validated)
* Probes and appends existing module subdirs under the Qt include root: `QtCore`, `QtGui`, `QtNetwork`, `QtOpenGL`, `QtXml`.
* Starts using `DUI::addIncludePath(...)` instead of pushing to the legacy `includePaths`.
* Removes hardcoded macOS `/Library/Frameworks/.../Headers` assumptions (to defer to new framework discovery).

## Generator: discover Qt framework paths dynamically (macOS)

* New `getFrameworkDirectories(...)` collects framework/library search roots from:

  * `.` (cwd)
  * `PYTHONQT_FRAMEWORK` (validated)
  * `--framework-paths` (validated)
  * `${QTDIR}/lib/<Module>.framework` when present, plus `${QTDIR}/lib`
  * `QLibraryInfo::LibrariesPath` when available
* Passes these paths to the preprocessor using `DUI::addFrameworkPath(...)`.

## Generator: detect Qt version from frameworks on macOS

* `getQtVersion(...)` now accepts either header include directories or framework roots.
* On macOS, probes `Versions/A/Headers/qtcoreversion.h` when given a framework root (e.g., `.../QtCore.framework`).
* Tries include paths first, then framework paths; aborts early with a clear error message if neither yields a version.

---

This pull request supersedes the following ones:
* #271 
* #299

---

This pull request fixes the following issues:

* Fixes #276
