### PR TITLE
chore: Remove obsolete Python 2 compatibility code

### DIFF
--- a/src/PythonQt.h
+++ b/src/PythonQt.h
@@ -147,15 +147,9 @@ typedef QObject* PythonQtQObjectCreatorFunctionCB();
 template<class T> QObject* PythonQtCreateObject() { return new T(); }
 
 //! Helper define to convert from QString to Python C-API
-#ifdef PY3K
 #define QStringToPythonConstCharPointer(arg) ((arg).toUtf8().constData())
 #define QStringToPythonCharPointer(arg) ((arg).toUtf8().data())
 #define QStringToPythonEncoding(arg) ((arg).toUtf8())
-#else
-#define QStringToPythonConstCharPointer(arg) ((arg).toLatin1().constData())
-#define QStringToPythonCharPointer(arg) ((arg).toLatin1().data())
-#define QStringToPythonEncoding(arg) ((arg).toLatin1())
-#endif
 
 //! The main interface to the Python Qt binding, realized as a singleton
 /*!
@@ -368,7 +362,6 @@ public:
   //! Parses the given file and returns the python code object, this can then be used to call evalCode()
   //! It uses Python's importlib machinery to load the file's code and supports source and sourceless loading
   //! and generation of cache files.
-  //! This method is PY3K only!
   PythonQtObjectPtr parseFileWithPythonLoaders(const QString& filename);
 
   //! evaluates the given code and returns the result value (use Py_Compile etc. to create pycode from string)

--- a/src/PythonQtBoolResult.cpp
+++ b/src/PythonQtBoolResult.cpp
@@ -58,7 +58,7 @@ static PyObject *PythonQtBoolResult_repr(PythonQtBoolResultObject *obj)
   return PyString_FromString(wrapper->_value?"BoolResult(True)":"BoolResult(False)");
 }
 
-static int PythonQtBoolResult_nonzero(PyObject *obj)
+static int PythonQtBoolResult_bool(PyObject *obj)
 {
   PythonQtBoolResultObject* wrapper = (PythonQtBoolResultObject*)obj;
   return wrapper->_value;
@@ -69,38 +69,25 @@ static PyNumberMethods PythonQtBoolResult_as_number = {
   nullptr,      /* nb_add */
   nullptr,      /* nb_subtract */
   nullptr,      /* nb_multiply */
-#ifndef PY3K
-  nullptr,      /* nb_divide */
-#endif
   nullptr,      /* nb_remainder */
   nullptr,      /* nb_divmod */
   nullptr,      /* nb_power */
   nullptr,      /* nb_negative */
   nullptr,      /* nb_positive */
   nullptr,      /* nb_absolute */
-  PythonQtBoolResult_nonzero,      /* nb_nonzero / nb_bool in Py3K */
+  PythonQtBoolResult_bool, /* nb_bool */
   nullptr,      /* nb_invert */
   nullptr,      /* nb_lshift */
   nullptr,      /* nb_rshift */
   nullptr,      /* nb_and */
   nullptr,      /* nb_xor */
   nullptr,      /* nb_or */
-#ifndef PY3K   
-  nullptr,      /* nb_coerce */
-#endif
   nullptr,      /* nb_int */
-  nullptr,      /* nb_long  / nb_reserved in Py3K */
+  nullptr,      /* nb_reserved */
   nullptr,      /* nb_float */
-#ifndef PY3K
-  nullptr,      /* nb_oct */
-  nullptr,      /* nb_hex */
-#endif
   nullptr,      /* nb_inplace_add */
   nullptr,      /* nb_inplace_subtract */
   nullptr,      /* nb_inplace_multiply */
-#ifndef PY3K
-  nullptr,      /* nb_inplace_divide */
-#endif
   nullptr,      /* nb_inplace_remainder */
   nullptr,      /* nb_inplace_power */
   nullptr,      /* nb_inplace_lshift */
@@ -112,9 +99,7 @@ static PyNumberMethods PythonQtBoolResult_as_number = {
   nullptr,      /* nb_true_divide */
   nullptr,      /* nb_inplace_floor_divide */
   nullptr,      /* nb_inplace_true_divide */
-#ifdef PY3K
-  nullptr,      /* nb_index in Py3K */
-#endif
+  nullptr,      /* nb_index */
 };
 
 PyTypeObject PythonQtBoolResult_Type = {
@@ -155,4 +140,3 @@ PyTypeObject PythonQtBoolResult_Type = {
     0,            /* tp_dictoffset */
     (initproc)&PythonQtBoolResult_init,      /* tp_init */
 };
-

--- a/src/PythonQtClassWrapper.cpp
+++ b/src/PythonQtClassWrapper.cpp
@@ -260,9 +260,6 @@ static void initializeSlots(PythonQtClassWrapper* wrap)
       wrap->_base.as_number.nb_multiply = (binaryfunc)PythonQtInstanceWrapper_mul;
     }
     if (typeSlots & PythonQt::Type_Divide) {
-#ifndef PY3K
-      wrap->_base.as_number.nb_divide = (binaryfunc)PythonQtInstanceWrapper_div;
-#endif
       wrap->_base.as_number.nb_true_divide = (binaryfunc)PythonQtInstanceWrapper_div;
     }
     if (typeSlots & PythonQt::Type_And) {
@@ -294,9 +291,6 @@ static void initializeSlots(PythonQtClassWrapper* wrap)
       wrap->_base.as_number.nb_inplace_multiply = (binaryfunc)PythonQtInstanceWrapper_imul;
     }
     if (typeSlots & PythonQt::Type_InplaceDivide) {
-#ifndef PY3K
-      wrap->_base.as_number.nb_inplace_divide = (binaryfunc)PythonQtInstanceWrapper_idiv;
-#endif
       wrap->_base.as_number.nb_inplace_true_divide = (binaryfunc)PythonQtInstanceWrapper_idiv;
     }
     if (typeSlots & PythonQt::Type_InplaceAnd) {
@@ -321,11 +315,7 @@ static void initializeSlots(PythonQtClassWrapper* wrap)
       wrap->_base.as_number.nb_invert = (unaryfunc)PythonQtInstanceWrapper_invert;
     }
     if (typeSlots & PythonQt::Type_NonZero) {
-#ifdef PY3K
       wrap->_base.as_number.nb_bool = (inquiry)PythonQtInstanceWrapper_nonzero;
-#else
-      wrap->_base.as_number.nb_nonzero = (inquiry)PythonQtInstanceWrapper_nonzero;
-#endif
     }
   }
 }
@@ -563,11 +553,7 @@ static PyObject *PythonQtClassWrapper_getattro(PyObject *obj, PyObject *name)
   }
 
   // look for the internal methods (className(), help())
-#ifdef PY3K
   PyObject* internalMethod = PyObject_GenericGetAttr(obj, name);
-#else
-  PyObject* internalMethod = Py_FindMethod( PythonQtClassWrapper_methods, obj, (char*)attributeName);
-#endif
   if (internalMethod) {
     return internalMethod;
   }
@@ -634,11 +620,7 @@ PyTypeObject PythonQtClassWrapper_Type = {
     0,                               /* tp_weaklistoffset */
     nullptr,                         /* tp_iter */
     nullptr,                         /* tp_iternext */
-    #ifdef PY3K
     PythonQtClassWrapper_methods,    /* tp_methods */
-    #else
-    nullptr,                         /* tp_methods */
-    #endif
     nullptr,                         /* tp_members */
     nullptr,                         /* tp_getset */
     nullptr,                         /* tp_base */
@@ -653,4 +635,3 @@ PyTypeObject PythonQtClassWrapper_Type = {
 };
 
 //-------------------------------------------------------
-

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -804,11 +804,7 @@ QString PythonQtConv::PyObjGetRepresentation(PyObject* val)
   QString r;
   PyObject* str =  PyObject_Repr(val);
   if (str) {
-    #ifdef PY3K
       r = PyObjGetString(str);
-    #else
-      r = QString(PyString_AS_STRING(str));
-    #endif
     Py_DECREF(str);
   }
   return r;
@@ -820,31 +816,12 @@ QString PythonQtConv::PyObjGetString(PyObject* val, bool strict, bool& ok) {
   if (val == nullptr) {
     r = "None";
   } else
-#ifndef PY3K
-  // in Python 3, we don't want to convert to QString, since we don't know anything about the encoding
-  // in Python 2, we assume the default for str is latin-1
-  if (val->ob_type == &PyBytes_Type) {
-    r = QString::fromLatin1(PyBytes_AS_STRING(val));
-  } else
-#endif
   if (PyUnicode_Check(val)) {
-#ifdef PY3K
     r = QString::fromUtf8(PyUnicode_AsUTF8(val));
-#else
-    PyObject *ptmp = PyUnicode_AsUTF8String(val);
-    if(ptmp) {
-      r = QString::fromUtf8(PyString_AS_STRING(ptmp));
-      Py_DECREF(ptmp);
-    }
-#endif
   } else if (!strict) {
     PyObject* str =  PyObject_Str(val);
     if (str) {
-#ifdef PY3K
       r = QString::fromUtf8(PyUnicode_AsUTF8(str));
-#else
-      r = QString(PyString_AS_STRING(str));
-#endif
       Py_DECREF(str);
     } else {
       ok = false;
@@ -942,11 +919,6 @@ int PythonQtConv::PyObjGetInt(PyObject* val, bool strict, bool &ok) {
 qint64 PythonQtConv::PyObjGetLongLong(PyObject* val, bool strict, bool &ok) {
   qint64 d = 0;
   ok = true;
-#ifndef PY3K
-  if (val->ob_type == &PyInt_Type) {
-    d = PyInt_AS_LONG(val);
-  } else
-#endif
   if (val->ob_type == &PyLong_Type) {
     d = PyLong_AsLongLong(val);
   } else if (!strict) {
@@ -977,11 +949,6 @@ qint64 PythonQtConv::PyObjGetLongLong(PyObject* val, bool strict, bool &ok) {
 quint64 PythonQtConv::PyObjGetULongLong(PyObject* val, bool strict, bool &ok) {
   quint64 d = 0;
   ok = true;
-#ifndef PY3K
-  if (Py_TYPE(val) == &PyInt_Type) {
-    d = PyInt_AS_LONG(val);
-  } else
-#endif
   if (Py_TYPE(val) == &PyLong_Type) {
     d = PyLong_AsUnsignedLongLong(val);
   } else if (!strict) {
@@ -1015,11 +982,6 @@ double PythonQtConv::PyObjGetDouble(PyObject* val, bool strict, bool &ok) {
   if (val->ob_type == &PyFloat_Type) {
     d = PyFloat_AS_DOUBLE(val);
   } else if (!strict) {
-#ifndef PY3K
-    if (PyObject_TypeCheck(val, &PyInt_Type)) {
-      d = PyInt_AS_LONG(val);
-    } else
-#endif
     if (PyLong_Check(val)) {
       d = static_cast<double>(PyLong_AsLongLong(val));
     } else if (val == Py_False) {
@@ -1090,21 +1052,11 @@ QVariant PythonQtConv::PyObjToQVariant(PyObject* val, int type)
     if (val == nullptr) {
       type = QMetaType::UnknownType; // Equivalent to QVariant::Invalid or unregistered type
     } else if (PyBytes_Check(val)) {
-#ifdef PY3K
-      // In Python 3, it is a ByteArray
       type = QMetaType::QByteArray;
-#else
-      // In Python 2, we need to use String, since it might be a string
-      type = QMetaType::QString;
-#endif
     } else if (PyUnicode_Check(val)) {
       type = QMetaType::QString;
     } else if (val == Py_False || val == Py_True) {
       type = QMetaType::Bool;
-#ifndef PY3K
-    } else if (PyObject_TypeCheck(val, &PyInt_Type)) {
-      type = QMetaType::Int;
-#endif
     } else if (PyLong_Check(val)) {
       // return int if the value fits into that range,
       // otherwise it would not be possible to get an int from Python 3
@@ -1236,11 +1188,7 @@ QVariant PythonQtConv::PyObjToQVariant(PyObject* val, int type)
   case QMetaType::QByteArray:
     {
       bool ok;
-#ifdef PY3K
       v = QVariant(PyObjGetBytes(val, false, ok));
-#else
-      v = QVariant(PyObjGetString(val, false, ok));
-#endif
     }
     break;
   case QMetaType::QString:
@@ -1634,10 +1582,6 @@ QByteArray PythonQtConv::getCPPTypeName(PyObject* type)
         result = "double";
       } else if (typeObject == &PyBool_Type) {
         result = "bool";
-#ifndef PY3K
-      } else if (typeObject == &PyInt_Type) {
-        result = "qint32";
-#endif
       } else if (typeObject == &PyLong_Type) {
         result = "qint64";
       } else if (isStringType(typeObject)) {
@@ -1657,11 +1601,7 @@ QByteArray PythonQtConv::getCPPTypeName(PyObject* type)
 
 bool PythonQtConv::isStringType(PyTypeObject* type)
 {
-#ifdef PY3K
   return type == &PyUnicode_Type;
-#else
-  return type == &PyUnicode_Type || type == &PyString_Type;
-#endif
 }
 
 void PythonQtConv::registerStringViewTypes()

--- a/src/PythonQtImporter.cpp
+++ b/src/PythonQtImporter.cpp
@@ -560,23 +560,11 @@ void PythonQtImport::writeCompiledModule(PyCodeObject *co, const QString& filena
       "# can't create %s\n", QStringToPythonConstCharPointer(filename));
     return;
   }
-#if PY_VERSION_HEX < 0x02040000
-  PyMarshal_WriteLongToFile(PyImport_GetMagicNumber(), fp);
-#else
   PyMarshal_WriteLongToFile(PyImport_GetMagicNumber(), fp, Py_MARSHAL_VERSION);
-#endif
   /* First write a 0 for mtime */
-#if PY_VERSION_HEX < 0x02040000
-  PyMarshal_WriteLongToFile(0L, fp);
-#else
   PyMarshal_WriteLongToFile(0L, fp, Py_MARSHAL_VERSION);
-#endif
   PyMarshal_WriteLongToFile(sourceSize, fp, Py_MARSHAL_VERSION);
-#if PY_VERSION_HEX < 0x02040000
-  PyMarshal_WriteObjectToFile((PyObject *)co, fp);
-#else
   PyMarshal_WriteObjectToFile((PyObject *)co, fp, Py_MARSHAL_VERSION);
-#endif
   if (ferror(fp)) {
     if (Py_VerboseFlag)
       PySys_WriteStderr("# can't write %s\n", QStringToPythonConstCharPointer(filename));
@@ -587,11 +575,7 @@ void PythonQtImport::writeCompiledModule(PyCodeObject *co, const QString& filena
   }
   /* Now write the true mtime */
   fseek(fp, 4L, 0);
-#if PY_VERSION_HEX < 0x02040000
-  PyMarshal_WriteLongToFile(mtime, fp);
-#else
   PyMarshal_WriteLongToFile(mtime, fp, Py_MARSHAL_VERSION);
-#endif
   fflush(fp);
   fclose(fp);
   if (Py_VerboseFlag) {

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -595,11 +595,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
   }
 
   // look for the internal methods (className(), help())
-#ifdef PY3K
   PyObject* internalMethod = PyObject_GenericGetAttr(obj, name);
-#else
-  PyObject* internalMethod = Py_FindMethod( PythonQtInstanceWrapper_methods, obj, (char*)attributeName);
-#endif
   if (internalMethod) {
     return internalMethod;
   }
@@ -791,7 +787,6 @@ static PyObject * PythonQtInstanceWrapper_str(PyObject * obj)
   // QByteArray should be directly returned as a str
   if (wrapper->classInfo()->metaTypeId() == QMetaType::QByteArray) {
     QByteArray* b = (QByteArray*) wrapper->_wrappedPtr;
-#ifdef PY3K
     // Note: In Python 2, this was used to access the data() of a byte array.
     // Since in Python 3 str() will return a unicode, this is no longer possible.
     // The user needs to call .data() to get access to the data as bytes.
@@ -803,13 +798,6 @@ static PyObject * PythonQtInstanceWrapper_str(PyObject * obj)
     } else {
       return PyUnicode_New(0, 0);
     }
-#else
-    if (b->data()) {
-      return PyString_FromStringAndSize(b->data(), b->size());
-    } else {
-      return PyString_FromString("");
-    }
-#endif
   }
 
   const char* typeName = obj->ob_type->tp_name;
@@ -857,7 +845,7 @@ static PyObject * PythonQtInstanceWrapper_repr(PyObject * obj)
   }
 }
 
-static int PythonQtInstanceWrapper_builtin_nonzero(PyObject *obj)
+static int PythonQtInstanceWrapper_builtin_bool(PyObject *obj)
 {
   PythonQtInstanceWrapper* wrapper = (PythonQtInstanceWrapper*)obj;
   return (wrapper->_wrappedPtr == nullptr && wrapper->_obj == nullptr)?0:1;
@@ -881,38 +869,25 @@ static PyNumberMethods PythonQtInstanceWrapper_as_number = {
     nullptr,      /* nb_add */
     nullptr,      /* nb_subtract */
     nullptr,      /* nb_multiply */
-#ifndef PY3K
-    nullptr,      /* nb_divide */
-#endif
     nullptr,      /* nb_remainder */
     nullptr,      /* nb_divmod */
     nullptr,      /* nb_power */
     nullptr,      /* nb_negative */
     nullptr,      /* nb_positive */
     nullptr,      /* nb_absolute */
-    PythonQtInstanceWrapper_builtin_nonzero,      /* nb_nonzero / nb_bool in Py3K */
+    PythonQtInstanceWrapper_builtin_bool, /* nb_bool */
     nullptr,      /* nb_invert */
     nullptr,      /* nb_lshift */
     nullptr,      /* nb_rshift */
     nullptr,      /* nb_and */
     nullptr,      /* nb_xor */
     nullptr,      /* nb_or */
-#ifndef PY3K
-    nullptr,      /* nb_coerce */
-#endif
     nullptr,      /* nb_int */
-    nullptr,      /* nb_long  / nb_reserved in Py3K */
+    nullptr,      /* nb_reserved */
     nullptr,      /* nb_float */
-#ifndef PY3K
-    nullptr,      /* nb_oct */
-    nullptr,      /* nb_hex */
-#endif
     nullptr,      /* nb_inplace_add */
     nullptr,      /* nb_inplace_subtract */
     nullptr,      /* nb_inplace_multiply */
-#ifndef PY3K
-    nullptr,      /* nb_inplace_divide */
-#endif
     nullptr,      /* nb_inplace_remainder */
     nullptr,      /* nb_inplace_power */
     nullptr,      /* nb_inplace_lshift */
@@ -924,9 +899,7 @@ static PyNumberMethods PythonQtInstanceWrapper_as_number = {
     nullptr,      /* nb_true_divide */
     nullptr,      /* nb_inplace_floor_divide */
     nullptr,      /* nb_inplace_true_divide */
-#ifdef PY3K
-    nullptr,      /* nb_index in Py3K */
-#endif
+    nullptr,      /* nb_index */
 };
 
 PyTypeObject PythonQtInstanceWrapper_Type = {
@@ -949,11 +922,7 @@ PyTypeObject PythonQtInstanceWrapper_Type = {
     PythonQtInstanceWrapper_getattro,            /*tp_getattro*/
     PythonQtInstanceWrapper_setattro,            /*tp_setattro*/
     nullptr,                                     /*tp_as_buffer*/
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE
-#ifndef PY3K
-    | Py_TPFLAGS_CHECKTYPES
-#endif
-    , /*tp_flags*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,    /* tp_flags */
     "PythonQtInstanceWrapper object",            /* tp_doc */
     nullptr,                                     /* tp_traverse */
     nullptr,                                     /* tp_clear */
@@ -961,11 +930,7 @@ PyTypeObject PythonQtInstanceWrapper_Type = {
     0,                                           /* tp_weaklistoffset */
     nullptr,                                     /* tp_iter */
     nullptr,                                     /* tp_iternext */
-#ifdef PY3K                                      
-    PythonQtInstanceWrapper_methods,             
-#else                                            
-    0,                                           /* tp_methods */
-#endif                                           
+    PythonQtInstanceWrapper_methods,             /* tp_methods */
     nullptr,                                     /* tp_members */
     nullptr,                                     /* tp_getset */
     nullptr,                                     /* tp_base */

--- a/src/PythonQtSignal.cpp
+++ b/src/PythonQtSignal.cpp
@@ -150,13 +150,6 @@ static PyObject *
 meth_get__self__(PythonQtSignalFunctionObject *m, void * /*closure*/)
 {
   PyObject *self;
-#ifndef PY3K
-  if (PyEval_GetRestricted()) {
-    PyErr_SetString(PyExc_RuntimeError,
-      "method.__self__ not accessible in restricted mode");
-    return NULL;
-  }
-#endif
   self = m->m_self;
   if (self == nullptr)
     self = Py_None;
@@ -409,11 +402,7 @@ PyTypeObject PythonQtSignalFunction_Type = {
     0,                        /* tp_vectorcall_offset */
     nullptr,                  /* tp_getattr */
     nullptr,                  /* tp_setattr */
-#ifdef PY3K
     nullptr,
-#else
-    (cmpfunc)meth_compare,    /* tp_compare */
-#endif
     (reprfunc)meth_repr,      /* tp_repr */
     nullptr,                  /* tp_as_number */
     nullptr,                  /* tp_as_sequence */

--- a/src/PythonQtSlot.cpp
+++ b/src/PythonQtSlot.cpp
@@ -609,13 +609,6 @@ static PyObject *
 meth_get__self__(PythonQtSlotFunctionObject *m, void * /*closure*/)
 {
   PyObject *self;
-#ifndef PY3K
-  if (PyEval_GetRestricted()) {
-    PyErr_SetString(PyExc_RuntimeError,
-      "method.__self__ not accessible in restricted mode");
-    return nullptr;
-  }
-#endif
   self = m->m_self;
   if (self == nullptr)
     self = Py_None;
@@ -828,11 +821,7 @@ PyTypeObject PythonQtSlotFunction_Type = {
     0,                          /* tp_vectorcall_offset */
     nullptr,                    /* tp_getattr */
     nullptr,                    /* tp_setattr */
-#ifdef PY3K
     nullptr,
-#else
-    (cmpfunc)meth_compare,      /* tp_compare */
-#endif
     (reprfunc)meth_repr,        /* tp_repr */
     nullptr,                    /* tp_as_number */
     nullptr,                    /* tp_as_sequence */

--- a/src/PythonQtStdOut.cpp
+++ b/src/PythonQtStdOut.cpp
@@ -61,27 +61,13 @@ static PyObject *PythonQtStdOutRedirect_write(PyObject *self, PyObject *args)
     if (PyTuple_GET_SIZE(args)>=1) {
       PyObject* obj = PyTuple_GET_ITEM(args,0);
       if (PyUnicode_Check(obj)) {
-#ifdef PY3K
         output = QString::fromUtf8(PyUnicode_AsUTF8(obj));
-#else
-        PyObject *tmp = PyUnicode_AsUTF8String(obj);
-        if(tmp) {
-          output = QString::fromUtf8(PyString_AS_STRING(tmp));
-          Py_DECREF(tmp);
-        } else {
-          return NULL;
-        }
-#endif
       } else {
         char *string;
         if (!PyArg_ParseTuple(args, "s", &string)) {
           return nullptr;
         }
-#ifdef PY3K
         output = QString::fromUtf8(string);
-#else
-        output = QString::fromLatin1(string);
-#endif
       }
     }
 

--- a/src/PythonQtUtils.h
+++ b/src/PythonQtUtils.h
@@ -85,12 +85,7 @@ namespace PythonQtUtils
 
   //! Returns of the python object is a class type
   inline bool isPythonClassType(PyObject* obj) {
-#ifdef PY3K
     return PyType_Check(obj);
-#else
-    // support old-style classes and new style classes
-    return (obj->ob_type == &PyClass_Type || obj->ob_type == &PyType_Type);
-#endif
   }
 
   //! Returns the meta type ID from a type name


### PR DESCRIPTION
This pull request removes obsolete compatibility code for Python 2 and outdated 
preprocessor conditionals for Python versions < 2.4.

* Remove all `#ifndef PY3K` conditionals and related branches, consolidating on Python 3 APIs. This drops redundant code paths and consistently renames `nb_nonzero` helpers to `nb_bool`.

* Remove the comment related to the use of `Py_FlushLine` in `custom_system_exit_exception_handle` in `PythonQt.cpp`, which is not needed in Python 3.x. See python/cpython@79139b247b0 ("Kill off softspace completely (except in formatter.py which seems to have a different feature with the same name). The change to test_doctest.txt reduces the doctest failures to 3.", 2007-02-09)

* Remove outdated `PY_VERSION_HEX` conditional branches.