### PR TITLE
chore: Replace deprecated Qt macros and Improve const correctness

### DIFF
--- a/examples/PyLauncher/main.cpp
+++ b/examples/PyLauncher/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
   }
   PythonQtScriptingConsole console(NULL, mainContext);
 
-  for (QString file : files) {
+  for (const QString& file : qAsConst(files)) {
     mainContext.evalFile(file);
   }
   if (showConsole || console.hadError()) {

--- a/examples/PyLauncher/main.cpp
+++ b/examples/PyLauncher/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
   }
   PythonQtScriptingConsole console(NULL, mainContext);
 
-  Q_FOREACH(QString file, files) {
+  for (QString file : files) {
     mainContext.evalFile(file);
   }
   if (showConsole || console.hadError()) {

--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -368,7 +368,7 @@ void AbstractMetaBuilder::traverseArithmeticOperator(FunctionModelItem item)
 void AbstractMetaBuilder::fixQObjectForScope(TypeDatabase *types,
            NamespaceModelItem scope)
 {
-    for (ClassModelItem item :  scope->classes()) {
+    for (const ClassModelItem& item : scope->classes()) {
         QString qualified_name = item->qualifiedName().join("::");
         TypeEntry *entry = types->findType(qualified_name);
         if (entry) {
@@ -378,7 +378,7 @@ void AbstractMetaBuilder::fixQObjectForScope(TypeDatabase *types,
         }
     }
 
-    for (NamespaceModelItem item :  scope->namespaceMap().values()) {
+    for (const NamespaceModelItem& item : scope->namespaceMap().values()) {
         if (scope != item)
             fixQObjectForScope(types, item);
     }
@@ -490,24 +490,21 @@ bool AbstractMetaBuilder::build()
     // First automatically add all enums marked as QEnum into the TypeDatabase
     // (if they don't contain an entry already). If there is an QEnum entry,
     // the enum is obviously meant for scripting.
-    for (ClassModelItem item : typeMap.values()) {
+    for (const ClassModelItem& item : typeMap.values()) {
         autoAddQEnumsForClassItem(item);
     }
 
-
-    for (ClassModelItem item :  typeMap.values()) {
+    for (const ClassModelItem& item : typeMap.values()) {
         AbstractMetaClass *cls = traverseClass(item);
         addAbstractMetaClass(cls);
     }
 
-
     QHash<QString, NamespaceModelItem> namespaceMap = m_dom->namespaceMap();
-    for (NamespaceModelItem item :  namespaceMap.values()) {
+    for (const NamespaceModelItem& item :  namespaceMap.values()) {
         AbstractMetaClass *meta_class = traverseNamespace(item);
         if (meta_class)
             m_meta_classes << meta_class;
     }
-
 
     // Some trickery to support global-namespace enums...
     QHash<QString, EnumModelItem> enumMap = m_dom->enumMap();
@@ -848,7 +845,7 @@ AbstractMetaEnum *AbstractMetaBuilder::traverseEnum(EnumModelItem enum_item, Abs
 
     ReportHandler::debugMedium(QString(" - traversing enum %1").arg(meta_enum->fullName()));
 
-    for (EnumeratorModelItem value :  enum_item->enumerators()) {
+    for (const EnumeratorModelItem& value : enum_item->enumerators()) {
         if (meta_enum->typeEntry()->isEnumValueRejected(value->name())) {
           continue;
         }
@@ -1077,7 +1074,7 @@ AbstractMetaField *AbstractMetaBuilder::traverseField(VariableModelItem field, c
 
 void AbstractMetaBuilder::traverseFields(ScopeModelItem scope_item, AbstractMetaClass *meta_class)
 {
-    for (VariableModelItem field :  scope_item->variables()) {
+    for (const VariableModelItem& field : scope_item->variables()) {
         AbstractMetaField *meta_field = traverseField(field, meta_class);
 
         if (meta_field) {
@@ -1108,7 +1105,7 @@ void AbstractMetaBuilder::setupFunctionDefaults(AbstractMetaFunction *meta_funct
 
 void AbstractMetaBuilder::traverseFunctions(ScopeModelItem scope_item, AbstractMetaClass *meta_class)
 {
-    for (FunctionModelItem function :  scope_item->functions()) {
+    for (const FunctionModelItem& function : scope_item->functions()) {
         AbstractMetaFunction *meta_function = traverseFunction(function);
 
         if (meta_function) {
@@ -2040,7 +2037,7 @@ bool AbstractMetaBuilder::inheritTemplate(AbstractMetaClass *subclass,
     }
 
     AbstractMetaFunctionList funcs = subclass->functions();
-    for (const AbstractMetaFunction *function :  template_class->functions()) {
+    for (const AbstractMetaFunction* function : template_class->functions()) {
 
         if (function->isModifiedRemoved(TypeSystem::All))
             continue;
@@ -2056,7 +2053,7 @@ bool AbstractMetaBuilder::inheritTemplate(AbstractMetaClass *subclass,
             continue;
         }
 
-        for (AbstractMetaArgument *argument :  function->arguments()) {
+        for (const AbstractMetaArgument* argument : function->arguments()) {
             AbstractMetaType::shared_pointer atype = argument->type();
 
             AbstractMetaArgument *arg = argument->copy();

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -158,7 +158,7 @@ AbstractMetaFunction::~AbstractMetaFunction()
 bool AbstractMetaFunction::isModifiedRemoved(int types) const
 {
     FunctionModificationList mods = modifications(implementingClass());
-    foreach (FunctionModification mod, mods) {
+    for (FunctionModification mod : mods) {
         if (!mod.isRemoveModifier())
             continue;
 
@@ -178,7 +178,7 @@ bool AbstractMetaFunction::needsCallThrough() const
     if (argumentsHaveNativeId() || !isStatic())
         return true;
 
-    foreach (const AbstractMetaArgument *arg, arguments()) {
+    for (const AbstractMetaArgument* arg : arguments()) {
         if (arg->type()->isArray() || arg->type()->isTargetLangEnum() || arg->type()->isTargetLangFlags())
             return true;
     }
@@ -186,7 +186,7 @@ bool AbstractMetaFunction::needsCallThrough() const
     if (type() && (type()->isArray() || type()->isTargetLangEnum() || type()->isTargetLangFlags()))
         return true;
 
-    for (int i=-1; i<=arguments().size(); ++i) {
+    for (int i=-1; i <= arguments().size(); ++i) {
         TypeSystem::Ownership owner = this->ownership(implementingClass(), TypeSystem::TargetLangCode, i);
         if (owner != TypeSystem::InvalidOwnership)
             return true;
@@ -199,7 +199,7 @@ bool AbstractMetaFunction::needsSuppressUncheckedWarning() const
 {
     for (int i=-1; i<=arguments().size(); ++i) {
         QList<ReferenceCount> referenceCounts = this->referenceCounts(implementingClass(), i);
-        foreach (ReferenceCount referenceCount, referenceCounts) {
+        for (ReferenceCount referenceCount : referenceCounts) {
             if (referenceCount.action != ReferenceCount::Set)
                 return true;
         }
@@ -211,7 +211,7 @@ QString AbstractMetaFunction::marshalledName() const
 {
     QString returned = "__qt_" + name();
     AbstractMetaArgumentList arguments = this->arguments();
-    foreach (const AbstractMetaArgument *arg, arguments) {
+    for (const AbstractMetaArgument* arg : arguments) {
         returned += "_";
         if (arg->type()->isNativePointer()) {
             returned += "nativepointer";
@@ -326,8 +326,9 @@ AbstractMetaFunction *AbstractMetaFunction::copy() const
     cpy->setException(exception());
     cpy->setOriginalAttributes(originalAttributes());
 
-    foreach (AbstractMetaArgument *arg, arguments())
+    for (AbstractMetaArgument* arg : arguments()) {
         cpy->addArgument(arg->copy());
+    }
 
     Q_ASSERT((!type() && !cpy->type())
              || (type()->instantiations() == cpy->type()->instantiations()));
@@ -397,9 +398,9 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
     QList<ReferenceCount> returned;
 
     FunctionModificationList mods = this->modifications(cls);
-    foreach (FunctionModification mod, mods) {
+    for (FunctionModification mod : mods) {
         QList<ArgumentModification> argument_mods = mod.argument_mods;
-        foreach (ArgumentModification argument_mod, argument_mods) {
+        for (ArgumentModification argument_mod : argument_mods) {
             if (argument_mod.index != idx && idx != -2)
                 continue;
             returned += argument_mod.referenceCounts;
@@ -412,9 +413,9 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
 QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.replaced_default_expression.isEmpty()) {
                 return argument_modification.replaced_default_expression;
@@ -428,9 +429,9 @@ QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass 
 bool AbstractMetaFunction::removedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && argument_modification.removed_default_expression) {
                 return true;
@@ -445,9 +446,9 @@ bool AbstractMetaFunction::resetObjectAfterUse(int argument_idx) const
 {
     const AbstractMetaClass *cls = declaringClass();
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argumentModifications = modification.argument_mods;
-        foreach (ArgumentModification argumentModification, argumentModifications) {
+        for (ArgumentModification argumentModification : argumentModifications) {
             if (argumentModification.index == argument_idx && argumentModification.reset_after_use)
                 return true;            
         }
@@ -466,9 +467,9 @@ QString AbstractMetaFunction::nullPointerDefaultValue(const AbstractMetaClass *m
 
     do {
         FunctionModificationList modifications = this->modifications(cls);
-        foreach (FunctionModification modification, modifications) {
+        for (FunctionModification modification : modifications) {
             QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            foreach (ArgumentModification argument_modification, argument_modifications) {
+            for (ArgumentModification argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return argument_modification.null_pointer_default_value;
@@ -491,9 +492,9 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
 
     do {
         FunctionModificationList modifications = this->modifications(cls);
-        foreach (FunctionModification modification, modifications) {
+        for (FunctionModification modification : modifications) {
             QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            foreach (ArgumentModification argument_modification, argument_modifications) {
+            for (ArgumentModification argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return true;
@@ -510,13 +511,13 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
 QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
-            foreach (CodeSnip snip, argument_modification.conversion_rules) {
+            for (CodeSnip snip : argument_modification.conversion_rules) {
                 if (snip.language == language && !snip.code().isEmpty())
                     return snip.code();
             }
@@ -529,9 +530,9 @@ QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int 
 QString AbstractMetaFunction::argumentReplaced(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key && !argument_modification.replace_value.isEmpty()) {
                 return argument_modification.replace_value;
             }
@@ -544,9 +545,9 @@ QString AbstractMetaFunction::argumentReplaced(int key) const
 bool AbstractMetaFunction::argumentRemoved(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key) {
                 if (argument_modification.removed) {
                     return true;
@@ -561,7 +562,7 @@ bool AbstractMetaFunction::argumentRemoved(int key) const
 bool AbstractMetaFunction::isVirtualSlot() const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if (modification.isVirtualSlot())
             return true;
     }
@@ -572,13 +573,13 @@ bool AbstractMetaFunction::isVirtualSlot() const
 bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cls, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
-            foreach (TypeSystem::Ownership ownership, argument_modification.ownerships.values()) {
+            for (TypeSystem::Ownership ownership : argument_modification.ownerships.values()) {
                 if (ownership == TypeSystem::CppOwnership)
                     return true;
             }
@@ -592,7 +593,7 @@ bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cl
 bool AbstractMetaFunction::isDeprecated() const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if (modification.isDeprecated())
             return true;
     }
@@ -602,9 +603,9 @@ bool AbstractMetaFunction::isDeprecated() const
 TypeSystem::Ownership AbstractMetaFunction::ownership(const AbstractMetaClass *cls, TypeSystem::Language language, int key) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key)
                 return argument_modification.ownerships.value(language, TypeSystem::InvalidOwnership);
         }
@@ -621,7 +622,7 @@ bool AbstractMetaFunction::isRemovedFromAllLanguages(const AbstractMetaClass *cl
 bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSystem::Language language) const
 {
     FunctionModificationList modifications = this->modifications(cls);
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         if ((modification.removal & language) == language)
             return true;
     }
@@ -633,9 +634,9 @@ bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSyste
 QString AbstractMetaFunction::typeReplaced(int key) const
 {
     FunctionModificationList modifications = this->modifications(declaringClass());
-    foreach (FunctionModification modification, modifications) {
+    for (FunctionModification modification : modifications) {
         QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        foreach (ArgumentModification argument_modification, argument_modifications) {
+        for (ArgumentModification argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.modified_type.isEmpty()) {
                 return argument_modification.modified_type;
@@ -688,7 +689,7 @@ QString AbstractMetaFunction::modifiedName() const
 {
     if (m_cached_modified_name.isEmpty()) {
         FunctionModificationList mods = modifications(implementingClass());
-        foreach (FunctionModification mod, mods) {
+        for (FunctionModification mod : mods) {
             if (mod.isRenameModifier()) {
                 m_cached_modified_name = mod.renamedToName;
                 break;
@@ -761,13 +762,13 @@ AbstractMetaClass::~AbstractMetaClass()
     cls->setAttributes(attributes());
     cls->setBaseClass(baseClass());
     cls->setTypeEntry(typeEntry());
-    foreach (AbstractMetaFunction *function, functions()) {
+    for (AbstractMetaFunction* function : functions()) {
         AbstractMetaFunction *copy = function->copy();
         function->setImplementingClass(cls);
         cls->addFunction(copy);
     }
     cls->setEnums(enums());
-    foreach (const AbstractMetaField *field, fields()) {
+    for (const AbstractMetaField* field : fields()) {
         AbstractMetaField *copy = field->copy();
         copy->setEnclosingClass(cls);
         cls->addField(copy);
@@ -811,7 +812,7 @@ AbstractMetaClass *AbstractMetaClass::extractInterface()
 
         iface->setTypeEntry(typeEntry()->designatedInterface());
 
-        foreach (AbstractMetaFunction *function, functions()) {
+        for (const AbstractMetaFunction* function : functions()) {
             if (!function->isConstructor())
                 iface->addFunction(function->copy());
         }
@@ -819,7 +820,7 @@ AbstractMetaClass *AbstractMetaClass::extractInterface()
 //         iface->setEnums(enums());
 //         setEnums(AbstractMetaEnumList());
 
-        foreach (const AbstractMetaField *field, fields()) {
+        for (const AbstractMetaField* field : fields()) {
             if (field->isPublic()) {
                 AbstractMetaField *new_field = field->copy();
                 new_field->setEnclosingClass(iface);
@@ -841,7 +842,7 @@ AbstractMetaFunctionList AbstractMetaClass::queryFunctionsByName(const QString &
 {
     AbstractMetaFunctionList returned;
     AbstractMetaFunctionList functions = this->functions();
-    foreach (AbstractMetaFunction *function, functions) {
+    for (AbstractMetaFunction* function : functions) {
         if (function->name() == name)
             returned.append(function);
     }
@@ -877,7 +878,7 @@ QList<ReferenceCount> AbstractMetaClass::referenceCounts() const
     QList<ReferenceCount> returned;
 
     AbstractMetaFunctionList functions = this->functions();
-    foreach (AbstractMetaFunction *function, functions) {
+    for (const AbstractMetaFunction* function : functions) {
         returned += function->referenceCounts(this);
     }
 
@@ -922,7 +923,7 @@ AbstractMetaFunctionList AbstractMetaClass::virtualFunctions() const
     AbstractMetaFunctionList list = functionsInShellClass();
 
     AbstractMetaFunctionList returned;
-    foreach (AbstractMetaFunction *f, list) {
+    for (AbstractMetaFunction* f : list) {
         if (!f->isFinalInCpp() || f->isVirtualSlot())
             returned += f;
     }
@@ -934,7 +935,7 @@ AbstractMetaFunctionList AbstractMetaClass::nonVirtualShellFunctions() const
 {
     AbstractMetaFunctionList list = functionsInShellClass();
     AbstractMetaFunctionList returned;
-    foreach (AbstractMetaFunction *f, list) {
+    for (AbstractMetaFunction* f : list) {
         if (f->isFinalInCpp() && !f->isVirtualSlot())
             returned += f;
     }
@@ -996,7 +997,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
     QString currentName;
     bool hasVirtuals = false;
     AbstractMetaFunctionList final_functions;
-    foreach (AbstractMetaFunction *f, m_functions) {
+    for (AbstractMetaFunction* f : m_functions) {
         f->setOwnerClass(this);
 
         m_has_virtual_slots |= f->isVirtualSlot();
@@ -1011,7 +1012,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
                 final_functions += f;
         } else {
             if (hasVirtuals && final_functions.size() > 0) {
-                foreach (AbstractMetaFunction *final_function, final_functions) {
+                for (AbstractMetaFunction* final_function : final_functions) {
                     *final_function += AbstractMetaAttributes::ForceShellImplementation;
 
                     QString warn = QString("hiding of function '%1' in class '%2'")
@@ -1034,7 +1035,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
         FunctionModificationList mods = m_functions.at(j)->modifications(m_functions.at(j)->implementingClass());
 
         bool removed = false;
-        foreach (const FunctionModification &mod, mods) {
+        for (const FunctionModification& mod : mods) {
             if (mod.isRemoveModifier()) {
                 removed = true;
                 break ;
@@ -1049,7 +1050,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
 
             mods = m_functions.at(i)->modifications(m_functions.at(i)->implementingClass());
             bool removed = false;
-            foreach (const FunctionModification &mod, mods) {
+            for (const FunctionModification& mod : mods) {
                 if (mod.isRemoveModifier()) {
                     removed = true;
                     break ;
@@ -1075,7 +1076,7 @@ void AbstractMetaClass::setFunctions(const AbstractMetaFunctionList &functions)
 
 bool AbstractMetaClass::hasFieldAccessors() const
 {
-    foreach (const AbstractMetaField *field, fields()) {
+    for (const AbstractMetaField* field : fields()) {
         if (field->getter() || field->setter())
             return true;
     }
@@ -1085,7 +1086,7 @@ bool AbstractMetaClass::hasFieldAccessors() const
 
 bool AbstractMetaClass::hasDefaultToStringFunction() const
 {
-    foreach (AbstractMetaFunction *f, queryFunctionsByName("toString")) {
+    for (AbstractMetaFunction* f : queryFunctionsByName("toString")) {
         if (f->actualMinimumArgumentCount() == 0) {
             return true;
         }
@@ -1130,7 +1131,7 @@ bool AbstractMetaClass::hasSignal(const AbstractMetaFunction *other) const
     if (!other->isSignal())
         return false;
 
-    foreach (const AbstractMetaFunction *f, functions()) {
+    for (const AbstractMetaFunction* f : functions()) {
         if (f->isSignal() && f->compareTo(other) & AbstractMetaFunction::EqualName)
             return other->modifiedName() == f->modifiedName();
     }
@@ -1146,7 +1147,7 @@ QString AbstractMetaClass::name() const
 
 bool AbstractMetaClass::hasFunction(const QString &str) const
 {
-    foreach (const AbstractMetaFunction *f, functions())
+    for (const AbstractMetaFunction* f : functions())
         if (f->name() == str)
             return true;
     return false;
@@ -1158,7 +1159,7 @@ bool AbstractMetaClass::hasFunction(const QString &str) const
    they can be called from the native functions.
 */
 bool AbstractMetaClass::hasProtectedFunctions() const {
-    foreach (AbstractMetaFunction *func, m_functions) {
+    for (AbstractMetaFunction* func : m_functions) {
         if (func->isProtected())
             return true;
     }
@@ -1220,7 +1221,7 @@ bool AbstractMetaClass::hasVirtualDestructor() const
 
 static bool functions_contains(const AbstractMetaFunctionList &l, const AbstractMetaFunction *func)
 {
-    foreach (const AbstractMetaFunction *f, l) {
+    for (const AbstractMetaFunction* f : l) {
                 if ((f->compareTo(func) & AbstractMetaFunction::PrettySimilar) == AbstractMetaFunction::PrettySimilar)
             return true;
     }
@@ -1278,7 +1279,7 @@ static AbstractMetaFunction *createXetter(const AbstractMetaField *g, const QStr
     f->setOriginalAttributes(attr);
 
     FieldModificationList mods = g->modifications();
-    foreach (FieldModification mod, mods) {
+    for (FieldModification mod : mods) {
         if (mod.isRenameModifier())
             f->setName(mod.renamedTo());
         if (mod.isAccessModifier()) {
@@ -1301,7 +1302,7 @@ FieldModificationList AbstractMetaField::modifications() const
     FieldModificationList mods = enclosingClass()->typeEntry()->fieldModifications();
     FieldModificationList returned;
 
-    foreach (FieldModification mod, mods) {
+    for (FieldModification mod : mods) {
         if (mod.name == name())
             returned += mod;
     }
@@ -1374,7 +1375,7 @@ AbstractMetaFunctionList AbstractMetaClass::queryFunctions(uint query) const
 {
     AbstractMetaFunctionList functions;
 
-    foreach (AbstractMetaFunction *f, m_functions) {
+    for (AbstractMetaFunction* f : m_functions) {
 
         if ((query & VirtualSlots) && !f->isVirtualSlot())
             continue;
@@ -1523,7 +1524,7 @@ void AbstractMetaClass::addInterface(AbstractMetaClass *interface)
     if (m_extracted_interface != 0 && m_extracted_interface != interface)
         m_extracted_interface->addInterface(interface);
 
-    foreach (AbstractMetaFunction *function, interface->functions())
+    for (AbstractMetaFunction* function : interface->functions())
         if (!hasFunction(function) && !function->isConstructor()) {
             AbstractMetaFunction *cpy = function->copy();
             // We do not want this in PythonQt:
@@ -1535,7 +1536,7 @@ void AbstractMetaClass::addInterface(AbstractMetaClass *interface)
 
             // Copy the modifications in interface into the implementing classes.
             //FunctionModificationList mods = function->modifications(interface);
-            //foreach  (const FunctionModification &mod, mods) {
+            //for (const FunctionModification& mod : mods) {
             //    m_type_entry->addFunctionModification(mod);
             //}
 
@@ -1556,7 +1557,7 @@ void AbstractMetaClass::setInterfaces(const AbstractMetaClassList &interfaces)
 
 AbstractMetaEnum *AbstractMetaClass::findEnum(const QString &enumName)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
+    for (AbstractMetaEnum* e : m_enums) {
         if (e->name() == enumName)
             return e;
     }
@@ -1576,10 +1577,10 @@ AbstractMetaEnum *AbstractMetaClass::findEnum(const QString &enumName)
 */
 AbstractMetaEnumValue *AbstractMetaClass::findEnumValue(const QString &enumValueName, AbstractMetaEnum *meta_enum)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
+    for (AbstractMetaEnum* e : m_enums) {
         if (e == meta_enum)
             continue;
-        foreach (AbstractMetaEnumValue *v, e->values()) {
+        for (AbstractMetaEnumValue* v : e->values()) {
             if (v->name() == enumValueName)
                 return v;
         }
@@ -1603,8 +1604,8 @@ AbstractMetaEnumValue *AbstractMetaClass::findEnumValue(const QString &enumValue
  */
 AbstractMetaEnum *AbstractMetaClass::findEnumForValue(const QString &enumValueName)
 {
-    foreach (AbstractMetaEnum *e, m_enums) {
-        foreach (AbstractMetaEnumValue *v, e->values()) {
+    for (AbstractMetaEnum* e : m_enums) {
+        for (AbstractMetaEnumValue* v : e->values()) {
             if (v->name() == enumValueName)
                 return e;
         }
@@ -1649,8 +1650,9 @@ static void add_extra_includes_for_function(AbstractMetaClass *meta_class, const
     add_extra_include_for_type(meta_class, meta_function->type());
 
     AbstractMetaArgumentList arguments = meta_function->arguments();
-    foreach (AbstractMetaArgument *argument, arguments)
+    for (AbstractMetaArgument* argument : arguments) {
         add_extra_include_for_type(meta_class, argument->type());
+    }
 }
 
 void AbstractMetaClass::fixFunctions()
@@ -1786,7 +1788,7 @@ void AbstractMetaClass::fixFunctions()
                                 bool hasNonFinalModifier = false;
                                 bool isBaseImplPrivate = false;
                                 FunctionModificationList mods = sf->modifications(sf->implementingClass());
-                                foreach (FunctionModification mod, mods) {
+                                for (FunctionModification mod : mods) {
                                     if (mod.isNonFinal()) {
                                         hasNonFinalModifier = true;
                                         break;
@@ -1842,8 +1844,9 @@ void AbstractMetaClass::fixFunctions()
                 funcs_to_add << sf;
         }
 
-        foreach (AbstractMetaFunction *f, funcs_to_add)
+        for (AbstractMetaFunction* f : funcs_to_add) {
             funcs << f->copy();
+        }
 
         if (super_class) {
             interfaceClasses += super_class->interfaces();
@@ -1857,9 +1860,9 @@ void AbstractMetaClass::fixFunctions()
 
     bool hasPrivateConstructors = false;
     bool hasPublicConstructors = false;
-    foreach (AbstractMetaFunction *func, funcs) {
+    for (AbstractMetaFunction* func : funcs) {
         FunctionModificationList mods = func->modifications(this);
-        foreach (const FunctionModification &mod, mods) {
+        for (const FunctionModification& mod : mods) {
             if (mod.isRenameModifier()) {
 //                 qDebug() << name() << func->originalName() << func << " from "
 //                          << func->implementingClass()->name() << "renamed to" << mod.renamedTo();
@@ -1896,8 +1899,8 @@ void AbstractMetaClass::fixFunctions()
     // we don't care about FinalOverload for PythonQt, so we
     // can remove this compare orgy...
     
-    /*foreach (AbstractMetaFunction *f1, funcs) {
-        foreach (AbstractMetaFunction *f2, funcs) {
+    /*for (AbstractMetaFunction* f1 : funcs) {
+        for (AbstractMetaFunction* f2 : funcs) {
             if (f1 != f2) {
                 uint cmp = f1->compareTo(f2);
                 if ((cmp & AbstractMetaFunction::EqualName)
@@ -1907,11 +1910,11 @@ void AbstractMetaClass::fixFunctions()
 //                     qDebug() << f2 << f2->implementingClass()->name() << "::" << f2->name() << f2->arguments().size() << " vs " << f1 << f1->implementingClass()->name() << "::" << f1->name() << f1->arguments().size();
 //                     qDebug() << "    " << f2;
 //                     AbstractMetaArgumentList f2Args = f2->arguments();
-//                     foreach (AbstractMetaArgument *a, f2Args)
+//                     for (AbstractMetaArgument* a : f2Args)
 //                         qDebug() << "        " << a->type()->name() << a->name();
 //                     qDebug() << "    " << f1;
 //                     AbstractMetaArgumentList f1Args = f1->arguments();
-//                     foreach (AbstractMetaArgument *a, f1Args)
+//                     for (AbstractMetaArgument* a : f1Args)
 //                         qDebug() << "        " << a->type()->name() << a->name();
 
                 }
@@ -2024,17 +2027,17 @@ AbstractMetaClass *AbstractMetaClassList::findClass(const QString &name) const
     if (name.isEmpty())
         return 0;
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass* c : *this) {
         if (c->qualifiedCppName() == name)
             return c;
     }
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass* c : *this) {
         if (c->fullName() == name)
             return c;
     }
 
-    foreach (AbstractMetaClass *c, *this) {
+    for (AbstractMetaClass* c : *this) {
         if (c->name() == name)
             return c;
     }

--- a/generator/abstractmetalang.cpp
+++ b/generator/abstractmetalang.cpp
@@ -198,8 +198,8 @@ bool AbstractMetaFunction::needsCallThrough() const
 bool AbstractMetaFunction::needsSuppressUncheckedWarning() const
 {
     for (int i=-1; i<=arguments().size(); ++i) {
-        QList<ReferenceCount> referenceCounts = this->referenceCounts(implementingClass(), i);
-        for (ReferenceCount referenceCount : referenceCounts) {
+        const QList<ReferenceCount> referenceCounts = this->referenceCounts(implementingClass(), i);
+        for (const ReferenceCount& referenceCount : referenceCounts) {
             if (referenceCount.action != ReferenceCount::Set)
                 return true;
         }
@@ -397,8 +397,8 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
 {
     QList<ReferenceCount> returned;
 
-    FunctionModificationList mods = this->modifications(cls);
-    for (FunctionModification mod : mods) {
+    const FunctionModificationList mods = this->modifications(cls);
+    for (const FunctionModification& mod : mods) {
         QList<ArgumentModification> argument_mods = mod.argument_mods;
         for (ArgumentModification argument_mod : argument_mods) {
             if (argument_mod.index != idx && idx != -2)
@@ -412,10 +412,10 @@ QList<ReferenceCount> AbstractMetaFunction::referenceCounts(const AbstractMetaCl
 
 QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.replaced_default_expression.isEmpty()) {
                 return argument_modification.replaced_default_expression;
@@ -428,10 +428,10 @@ QString AbstractMetaFunction::replacedDefaultExpression(const AbstractMetaClass 
 
 bool AbstractMetaFunction::removedDefaultExpression(const AbstractMetaClass *cls, int key) const
 {
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && argument_modification.removed_default_expression) {
                 return true;
@@ -445,10 +445,10 @@ bool AbstractMetaFunction::removedDefaultExpression(const AbstractMetaClass *cls
 bool AbstractMetaFunction::resetObjectAfterUse(int argument_idx) const
 {
     const AbstractMetaClass *cls = declaringClass();
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argumentModifications = modification.argument_mods;
-        for (ArgumentModification argumentModification : argumentModifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argumentModifications = modification.argument_mods;
+        for (const ArgumentModification& argumentModification : argumentModifications) {
             if (argumentModification.index == argument_idx && argumentModification.reset_after_use)
                 return true;            
         }
@@ -466,10 +466,10 @@ QString AbstractMetaFunction::nullPointerDefaultValue(const AbstractMetaClass *m
         cls = implementingClass();
 
     do {
-        FunctionModificationList modifications = this->modifications(cls);
-        for (FunctionModification modification : modifications) {
-            QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            for (ArgumentModification argument_modification : argument_modifications) {
+        const FunctionModificationList modifications = this->modifications(cls);
+        for (const FunctionModification& modification : modifications) {
+            const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+            for (const ArgumentModification& argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return argument_modification.null_pointer_default_value;
@@ -491,10 +491,10 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
         cls = implementingClass();
 
     do {
-        FunctionModificationList modifications = this->modifications(cls);
-        for (FunctionModification modification : modifications) {
-            QList<ArgumentModification> argument_modifications = modification.argument_mods;
-            for (ArgumentModification argument_modification : argument_modifications) {
+        const FunctionModificationList& modifications = this->modifications(cls);
+        for (const FunctionModification& modification : modifications) {
+            const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+            for (const ArgumentModification& argument_modification : argument_modifications) {
                 if (argument_modification.index == argument_idx
                     && argument_modification.no_null_pointers) {
                     return true;
@@ -510,10 +510,10 @@ bool AbstractMetaFunction::nullPointersDisabled(const AbstractMetaClass *mainCla
 
 QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int key) const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
@@ -529,10 +529,10 @@ QString AbstractMetaFunction::conversionRule(TypeSystem::Language language, int 
 
 QString AbstractMetaFunction::argumentReplaced(int key) const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key && !argument_modification.replace_value.isEmpty()) {
                 return argument_modification.replace_value;
             }
@@ -544,10 +544,10 @@ QString AbstractMetaFunction::argumentReplaced(int key) const
 
 bool AbstractMetaFunction::argumentRemoved(int key) const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key) {
                 if (argument_modification.removed) {
                     return true;
@@ -561,8 +561,8 @@ bool AbstractMetaFunction::argumentRemoved(int key) const
 
 bool AbstractMetaFunction::isVirtualSlot() const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
         if (modification.isVirtualSlot())
             return true;
     }
@@ -572,14 +572,14 @@ bool AbstractMetaFunction::isVirtualSlot() const
 
 bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cls, int key) const
 {
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index != key)
                 continue;
 
-            for (TypeSystem::Ownership ownership : argument_modification.ownerships.values()) {
+            for (const TypeSystem::Ownership& ownership : argument_modification.ownerships.values()) {
                 if (ownership == TypeSystem::CppOwnership)
                     return true;
             }
@@ -592,8 +592,8 @@ bool AbstractMetaFunction::disabledGarbageCollection(const AbstractMetaClass *cl
 
 bool AbstractMetaFunction::isDeprecated() const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
         if (modification.isDeprecated())
             return true;
     }
@@ -602,10 +602,10 @@ bool AbstractMetaFunction::isDeprecated() const
 
 TypeSystem::Ownership AbstractMetaFunction::ownership(const AbstractMetaClass *cls, TypeSystem::Language language, int key) const
 {
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key)
                 return argument_modification.ownerships.value(language, TypeSystem::InvalidOwnership);
         }
@@ -621,8 +621,8 @@ bool AbstractMetaFunction::isRemovedFromAllLanguages(const AbstractMetaClass *cl
 
 bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSystem::Language language) const
 {
-    FunctionModificationList modifications = this->modifications(cls);
-    for (FunctionModification modification : modifications) {
+    const FunctionModificationList modifications = this->modifications(cls);
+    for (const FunctionModification& modification : modifications) {
         if ((modification.removal & language) == language)
             return true;
     }
@@ -633,10 +633,10 @@ bool AbstractMetaFunction::isRemovedFrom(const AbstractMetaClass *cls, TypeSyste
 
 QString AbstractMetaFunction::typeReplaced(int key) const
 {
-    FunctionModificationList modifications = this->modifications(declaringClass());
-    for (FunctionModification modification : modifications) {
-        QList<ArgumentModification> argument_modifications = modification.argument_mods;
-        for (ArgumentModification argument_modification : argument_modifications) {
+    const FunctionModificationList modifications = this->modifications(declaringClass());
+    for (const FunctionModification& modification : modifications) {
+        const QList<ArgumentModification> argument_modifications = modification.argument_mods;
+        for (const ArgumentModification& argument_modification : argument_modifications) {
             if (argument_modification.index == key
                 && !argument_modification.modified_type.isEmpty()) {
                 return argument_modification.modified_type;
@@ -688,8 +688,8 @@ bool AbstractMetaFunction::hasModifications(const AbstractMetaClass *implementor
 QString AbstractMetaFunction::modifiedName() const
 {
     if (m_cached_modified_name.isEmpty()) {
-        FunctionModificationList mods = modifications(implementingClass());
-        for (FunctionModification mod : mods) {
+        const FunctionModificationList mods = modifications(implementingClass());
+        for (const FunctionModification& mod : mods) {
             if (mod.isRenameModifier()) {
                 m_cached_modified_name = mod.renamedToName;
                 break;
@@ -920,7 +920,7 @@ AbstractMetaFunctionList AbstractMetaClass::functionsInTargetLang() const
 
 AbstractMetaFunctionList AbstractMetaClass::virtualFunctions() const
 {
-    AbstractMetaFunctionList list = functionsInShellClass();
+    const AbstractMetaFunctionList list = functionsInShellClass();
 
     AbstractMetaFunctionList returned;
     for (AbstractMetaFunction* f : list) {
@@ -1278,8 +1278,8 @@ static AbstractMetaFunction *createXetter(const AbstractMetaField *g, const QStr
     f->setAttributes(attr);
     f->setOriginalAttributes(attr);
 
-    FieldModificationList mods = g->modifications();
-    for (FieldModification mod : mods) {
+    const FieldModificationList mods = g->modifications();
+    for (const FieldModification& mod : mods) {
         if (mod.isRenameModifier())
             f->setName(mod.renamedTo());
         if (mod.isAccessModifier()) {

--- a/generator/abstractmetalang.h
+++ b/generator/abstractmetalang.h
@@ -437,7 +437,7 @@ public:
     // true if one or more of the arguments are of QtJambiObject subclasses
     bool argumentsHaveNativeId() const
     {
-        foreach (const AbstractMetaArgument *arg, m_arguments) {
+        for (const AbstractMetaArgument* arg : m_arguments) {
             if (arg->type()->hasNativeId())
                 return true;
         }

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -63,7 +63,7 @@ void Generator::generate()
 
     m_classes.sort();
 
-    foreach (AbstractMetaClass *cls, m_classes) {
+    for (AbstractMetaClass* cls : m_classes) {
         if (!shouldGenerate(cls))
             continue;
 
@@ -87,7 +87,7 @@ void Generator::printClasses()
     AbstractMetaClassList classes = m_classes;
     classes.sort();
 
-    foreach (AbstractMetaClass *cls, classes) {
+    for (AbstractMetaClass* cls : classes) {
         if (!shouldGenerate(cls))
             continue;
         write(s, cls);
@@ -127,10 +127,10 @@ bool Generator::hasDefaultConstructor(const AbstractMetaType *type)
     QString full_name = type->typeEntry()->qualifiedTargetLangName();
     QString class_name = type->typeEntry()->targetLangName();
 
-    foreach (const AbstractMetaClass *java_class, m_classes) {
+    for (const AbstractMetaClass* java_class : m_classes) {
         if (java_class->typeEntry()->qualifiedTargetLangName() == full_name) {
             AbstractMetaFunctionList functions = java_class->functions();
-            foreach (const AbstractMetaFunction *function, functions) {
+            for (const AbstractMetaFunction* function : functions) {
                 if (function->arguments().size() == 0 && function->name() == class_name)
                     return true;
             }

--- a/generator/parser/binder.cpp
+++ b/generator/parser/binder.cpp
@@ -331,7 +331,7 @@ void Binder::declare_symbol(SimpleDeclarationAST *node, InitDeclaratorAST *init_
       fun->setVariadics (decl_cc.isVariadics ());
 
       // ... and the signature
-      foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+      for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
         {
           ArgumentModelItem arg = model()->create<ArgumentModelItem>();
           arg->setType(qualifyType(p.type, _M_context));
@@ -361,8 +361,9 @@ void Binder::declare_symbol(SimpleDeclarationAST *node, InitDeclaratorAST *init_
         {
           typeInfo.setFunctionPointer (true);
           decl_cc.run (init_declarator->declarator);
-          foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+          for (DeclaratorCompiler::Parameter p : decl_cc.parameters()) {
             typeInfo.addArgument(p.type);
+          }
         }
 
       var->setType(qualifyType(typeInfo, _M_context));
@@ -426,7 +427,7 @@ void Binder::visitFunctionDefinition(FunctionDefinitionAST *node)
     }
 
   decl_cc.run(declarator);
-  foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters()) {
+  for (DeclaratorCompiler::Parameter p : decl_cc.parameters()) {
     if (p.type.isRvalueReference()) {
       //warnHere();
       //std::cerr << "** Skipping function with rvalue reference parameter: "
@@ -481,7 +482,7 @@ void Binder::visitFunctionDefinition(FunctionDefinitionAST *node)
   }
   _M_current_function->setVariadics (decl_cc.isVariadics ());
 
-  foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+  for (DeclaratorCompiler::Parameter p : decl_cc.parameters())
     {
       ArgumentModelItem arg = model()->create<ArgumentModelItem>();
       
@@ -650,8 +651,9 @@ void Binder::visitTypedef(TypedefAST *node)
         {
           typeInfo.setFunctionPointer (true);
           decl_cc.run (init_declarator->declarator);
-          foreach (DeclaratorCompiler::Parameter p, decl_cc.parameters())
+          for (DeclaratorCompiler::Parameter p : decl_cc.parameters()) {
             typeInfo.addArgument(p.type);
+          }
         }
 
       ScopeModelItem scope = currentScope();
@@ -1029,7 +1031,7 @@ TypeInfo Binder::qualifyType(const TypeInfo &type, const QStringList &context) c
 
           if (ClassModelItem klass = scope.dynamicCast<_ClassModelItem> ())
             {
-              foreach (QString base, klass->baseClasses ())
+              for (QString base : klass->baseClasses())
                 {
                   QStringList ctx = context;
                   ctx.removeLast();

--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -212,7 +212,8 @@ QString TypeInfo::toString(bool parsable) const
       tmp += QLatin1String(")");
     }
 
-  for (QString elt : this->arrayElements())
+  const QStringList arrayElements = this->arrayElements();
+  for (const QString& elt : arrayElements)
     {
       tmp += QLatin1String ("[");
       tmp += elt;
@@ -398,9 +399,9 @@ void _ClassModelItem::addPropertyDeclaration(const QString &propertyDeclaration)
 // ---------------------------------------------------------------------------
 FunctionModelItem _ScopeModelItem::declaredFunction(FunctionModelItem item)
 {
-  FunctionList function_list = findFunctions(item->name());
+  const FunctionList function_list = findFunctions(item->name());
 
-  for (FunctionModelItem fun : function_list)
+  for (const FunctionModelItem& fun : function_list)
     {
       if (fun->isSimilar(item))
         return fun;

--- a/generator/parser/codemodel.cpp
+++ b/generator/parser/codemodel.cpp
@@ -212,7 +212,7 @@ QString TypeInfo::toString(bool parsable) const
       tmp += QLatin1String(")");
     }
 
-  foreach (QString elt, arrayElements ())
+  for (QString elt : this->arrayElements())
     {
       tmp += QLatin1String ("[");
       tmp += elt;
@@ -400,7 +400,7 @@ FunctionModelItem _ScopeModelItem::declaredFunction(FunctionModelItem item)
 {
   FunctionList function_list = findFunctions(item->name());
 
-  foreach (FunctionModelItem fun, function_list)
+  for (FunctionModelItem fun : function_list)
     {
       if (fun->isSimilar(item))
         return fun;

--- a/generator/prigenerator.cpp
+++ b/generator/prigenerator.cpp
@@ -145,7 +145,7 @@ void PriGenerator::generate()
         }
       
         file.stream << "HEADERS += \\\n";
-        foreach (const QString &entry, list) {
+        for (const QString& entry : list) {
           file.stream << "           $$PWD/" << entry << " \\\n";
         }
 
@@ -156,7 +156,7 @@ void PriGenerator::generate()
         if (compact) {
           list = compactFiles(list, ".cpp", m_out_dir + "/generated_cpp/" + folder, folder); 
         }
-        foreach (const QString &entry, list) {
+        for (const QString& entry : list) {
             file.stream << "           $$PWD/" << entry << " \\\n";
         }
         file.stream << "           $$PWD/" << folder << "_init.cpp\n";

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -63,7 +63,7 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
     }
   }
   QSet<QString> r;
-  for (QString op :
+  for (const QString& op :
 #       if QT_VERSION < QT_VERSION_CHECK(5,14,0)
               operatorCodes.toList()
 #       else

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -56,7 +56,7 @@ static QStringList getOperatorCodes(const AbstractMetaClass* cls) {
   QSet<QString> operatorCodes;
   AbstractMetaFunctionList returned;
   AbstractMetaFunctionList functions = cls->functions();
-  foreach (AbstractMetaFunction *function, functions) {
+  for (AbstractMetaFunction* function : functions) {
     if (function->originalName().startsWith("operator")) {
       QString op = function->originalName().mid(8);
       operatorCodes.insert(op);
@@ -182,7 +182,7 @@ static void addListRegistration(AbstractMetaType::shared_pointer type, QSet<QStr
     
     /*
     QString debugStr;
-    Q_FOREACH(AbstractMetaType* arg, args) {
+    for (AbstractMetaType* arg : args) {
       debugStr += QString(arg->typeEntry()->isEnum()?"ENUM ":"") + arg->typeEntry()->qualifiedCppName() + ",";
       if (arg->typeEntry()->qualifiedCppName() == "QPair") {
         debugStr += "(" + arg->instantiations().at(0)->typeEntry()->qualifiedCppName() + ",";
@@ -238,7 +238,7 @@ void SetupGenerator::generate()
     while (pack.hasNext()) {
       pack.next();
       QList<const AbstractMetaClass*> list = pack.value();
-      foreach (const AbstractMetaClass *cls, list) {
+      for (const AbstractMetaClass* cls : list) {
         if (cls->typeEntry()->isPolymorphicBase()) {
           classes_with_polymorphic_id.append((AbstractMetaClass*)cls);
         }
@@ -325,7 +325,7 @@ void SetupGenerator::generate()
       // declare individual class creation functions
       s << "void PythonQt_init_" << initName << "(PyObject* module) {" << endl;
 
-      foreach (const AbstractMetaClass *cls, list) {
+      for (const AbstractMetaClass* cls : list) {
         if (cls->qualifiedCppName().contains("Ssl")) {
           s << "#ifndef QT_NO_SSL"  << endl;
         }
@@ -376,7 +376,7 @@ void SetupGenerator::generate()
         }
       }
       s << endl;
-      foreach (QString handler, polymorphicHandlers) {
+      for (QString handler : polymorphicHandlers) {
         s << "PythonQt::self()->addPolymorphicHandler(\""<< handler << "\", polymorphichandler_" << handler << ");" << endl;
       }
       s << endl;
@@ -407,14 +407,14 @@ QStringList SetupGenerator::writePolymorphicHandler(QTextStream &s, const QStrin
                                                     const AbstractMetaClassList &polybase, QList<const AbstractMetaClass*>& allClasses)
 {
   QStringList handlers;
-  foreach (AbstractMetaClass *cls, polybase) {
+  for (AbstractMetaClass* cls : polybase) {
     const ComplexTypeEntry *centry = cls->typeEntry();
     if (!centry->isPolymorphicBase())
       continue;
     bool isGraphicsItem = (cls->qualifiedCppName()=="QGraphicsItem");
 
     bool first = true;
-    foreach (const AbstractMetaClass *clazz, allClasses) {
+    for (const AbstractMetaClass* clazz : allClasses) {
       bool inherits = false;
       if (isGraphicsItem) {
         const AbstractMetaClass *currentClazz = clazz;

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -88,7 +88,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
 
   IncludeList list = meta_class->typeEntry()->extraIncludes();
   std::sort(list.begin(), list.end());
-  foreach (const Include &inc, list) {
+  for (const Include& inc : list) {
     ShellGenerator::writeInclude(s, inc);
   }  
   s << endl;
@@ -122,7 +122,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
     s << "}" << endl;
 
     AbstractMetaFunctionList virtualsForShell = getVirtualFunctionsForShell(meta_class);
-    foreach (const AbstractMetaFunction *fun, virtualsForShell) {
+    for (const AbstractMetaFunction* fun : virtualsForShell) {
       bool hasReturnValue = !fun->type().isNull();
       writeFunctionSignature(s, fun, meta_class, QString(),
         Option(ShowStatic | UnderscoreSpaces | UseIndexedName),
@@ -234,7 +234,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   if (meta_class->generateShellClass() || !meta_class->isAbstract()) {
 
     // write constructors
-    foreach (const AbstractMetaFunction *ctor, ctors) {
+    for (const AbstractMetaFunction* ctor : ctors) {
       if (ctor->isAbstract() || (!meta_class->generateShellClass() && !ctor->isPublic())) { continue; }
 
       s << meta_class->qualifiedCppName() << "* ";
@@ -382,7 +382,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
 void ShellImplGenerator::writeInjectedCode(QTextStream &s, const AbstractMetaClass *meta_class)
 {
   CodeSnipList code_snips = meta_class->typeEntry()->codeSnips();
-  foreach (const CodeSnip &cs, code_snips) {
+  for (const CodeSnip& cs : code_snips) {
     if (cs.language == TypeSystem::PyWrapperCode) {
       s << cs.code() << endl;
     }

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1341,7 +1341,8 @@ bool Handler::startElement(const QString &, const QString &n,
 
                 if (rc.action == ReferenceCount::Invalid) {
                     m_error = "unrecognized value for action attribute. supported actions:";
-                    foreach (QString action, actions.keys())
+                    QStringList actionKeys = actions.keys();
+                    for (QString action : actionKeys)
                         m_error += " " + action;
                 }
 
@@ -1654,8 +1655,8 @@ ContainerTypeEntry *TypeDatabase::findContainerType(const QString &name)
 
 PrimitiveTypeEntry *TypeDatabase::findTargetLangPrimitiveType(const QString &java_name)
 {
-    foreach (QList<TypeEntry *> entries, m_entries.values()) {
-        foreach (TypeEntry *e, entries) {
+    for (QList<TypeEntry*> entries : m_entries.values()) {
+        for (TypeEntry* e : entries) {
             if (e && e->isPrimitive()) {
                 PrimitiveTypeEntry *pe = static_cast<PrimitiveTypeEntry *>(e);
                 if (pe->targetLangName() == java_name && pe->preferredConversion())
@@ -1800,7 +1801,7 @@ bool TypeDatabase::isClassRejected(const QString &class_name)
     if (!m_rebuild_classes.isEmpty())
         return !m_rebuild_classes.contains(class_name);
 
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection& r : m_rejections)
         if (r.class_name == class_name && r.function_name == "*" && r.field_name == "*" && r.enum_name == "*") {
             return true;
         }
@@ -1809,7 +1810,7 @@ bool TypeDatabase::isClassRejected(const QString &class_name)
 
 bool TypeDatabase::isEnumRejected(const QString &class_name, const QString &enum_name)
 {
-    foreach (const TypeRejection &r, m_rejections) {
+    for (const TypeRejection& r : m_rejections) {
         if (r.enum_name == enum_name
             && (r.class_name == class_name || r.class_name == "*")) {
             return true;
@@ -1821,7 +1822,7 @@ bool TypeDatabase::isEnumRejected(const QString &class_name, const QString &enum
 
 bool TypeDatabase::isFunctionRejected(const QString &class_name, const QString &function_name)
 {
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection& r : m_rejections)
         if (r.function_name == function_name &&
             (r.class_name == class_name || r.class_name == "*"))
             return true;
@@ -1831,7 +1832,7 @@ bool TypeDatabase::isFunctionRejected(const QString &class_name, const QString &
 
 bool TypeDatabase::isFieldRejected(const QString &class_name, const QString &field_name)
 {
-    foreach (const TypeRejection &r, m_rejections)
+    for (const TypeRejection& r : m_rejections)
         if (r.field_name == field_name &&
             (r.class_name == class_name || r.class_name == "*"))
             return true;
@@ -1991,7 +1992,7 @@ QString FunctionModification::toString() const
     if (modifiers & Writable) str += QLatin1String("writable");
 
     if (modifiers & CodeInjection) {
-        foreach (CodeSnip s, snips) {
+        for (CodeSnip s : snips) {
             str += QLatin1String("\n//code injection:\n");
             str += s.code();
         }

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -1160,7 +1160,7 @@ public:
 
     TypeEntry *findType(const QString &name) const {
         QList<TypeEntry *> entries = findTypes(name);
-        foreach (TypeEntry *entry, entries) {
+        for (TypeEntry* entry : entries) {
             if (entry != 0 &&
                 (!entry->isPrimitive() || static_cast<PrimitiveTypeEntry *>(entry)->preferredTargetLangType())) {
                 return entry;
@@ -1212,7 +1212,7 @@ public:
         if (!m_suppressWarnings)
             return false;
 
-        foreach (const QString &_warning, m_suppressedWarnings) {
+        for (const QString& _warning : m_suppressedWarnings) {
             QString warning(QString(_warning).replace("\\*", "&place_holder_for_asterisk;"));
 
             QStringList segs = warning.split("*", Qt::SkipEmptyParts);
@@ -1256,7 +1256,7 @@ inline PrimitiveTypeEntry *TypeDatabase::findPrimitiveType(const QString &name)
 {
     QList<TypeEntry *> entries = findTypes(name);
 
-    foreach (TypeEntry *entry, entries) {
+    for (TypeEntry* entry : entries) {
         if (entry != 0 && entry->isPrimitive() && static_cast<PrimitiveTypeEntry *>(entry)->preferredTargetLangType())
             return static_cast<PrimitiveTypeEntry *>(entry);
     }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1527,7 +1527,8 @@ void PythonQtPrivate::setupSharedLibrarySuffixes()
   _sharedLibrarySuffixes << "_d.so";
   #endif
 #endif
-  Q_FOREACH (QVariant entry, result.toList()) {
+  QVariantList entries = result.toList();
+  for (QVariant entry : entries) {
     QVariantList suffixEntry = entry.toList();
     if (suffixEntry.count()==3) {
       int code = suffixEntry.at(2).toInt();
@@ -1600,7 +1601,7 @@ void PythonQtPrivate::addDecorators(QObject* o, int decoTypes)
 
 void PythonQtPrivate::registerQObjectClassNames(const QStringList& names)
 {
-  Q_FOREACH(QString name, names) {
+  for (QString name : names) {
     _knownQObjectClassNames.insert(name.toUtf8(), true);
   }
 }
@@ -1615,7 +1616,7 @@ void PythonQt::removeSignalHandlers()
   QList<PythonQtSignalReceiver*> signalReceivers = _p->_signalReceivers.values();
 
   // just delete all signal receivers, they will remove themselves via removeSignalEmitter()
-  foreach(PythonQtSignalReceiver* receiver, signalReceivers) {
+  for (PythonQtSignalReceiver* receiver : signalReceivers) {
     delete receiver;
   }
   // just to be sure, clear the receiver map as well
@@ -1746,7 +1747,7 @@ void PythonQt::overwriteSysPath(const QStringList& paths)
   // Since Python uses os.path.sep at various places,
   // makse sure that we use the native path separators.
   QStringList nativePaths;
-  foreach(QString path, paths) {
+  for (QString path : paths) {
     nativePaths << QDir::toNativeSeparators(path);
   }
   PyModule_AddObject(sys, "path", PythonQtConv::QStringListToPyList(nativePaths));
@@ -2180,7 +2181,7 @@ PyObject* PythonQt::helpCalled(PythonQtClassInfo* info)
 
 void PythonQt::clearNotFoundCachedMembers()
 {
-  Q_FOREACH(PythonQtClassInfo* info, _p->_knownClassInfos) {
+  for (PythonQtClassInfo* info : _p->_knownClassInfos) {
     info->clearNotFoundCachedMembers();
   }
 }
@@ -2309,7 +2310,7 @@ const QMetaObject* PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper*
       PythonQtSignalFunctionObject* signal = (PythonQtSignalFunctionObject*)value;
       if (signal->_dynamicInfo) {
         signal->_dynamicInfo->name = PyString_AsString(key);
-        foreach(QByteArray sig, signal->_dynamicInfo->signatures) {
+        for (QByteArray sig : signal->_dynamicInfo->signatures) {
           builder.addSignal(signal->_dynamicInfo->name + "(" + sig + ")");
           needsMetaObject = true;
         }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1527,8 +1527,8 @@ void PythonQtPrivate::setupSharedLibrarySuffixes()
   _sharedLibrarySuffixes << "_d.so";
   #endif
 #endif
-  QVariantList entries = result.toList();
-  for (QVariant entry : entries) {
+  const QVariantList entries = result.toList();
+  for (const QVariant& entry : entries) {
     QVariantList suffixEntry = entry.toList();
     if (suffixEntry.count()==3) {
       int code = suffixEntry.at(2).toInt();
@@ -1601,7 +1601,7 @@ void PythonQtPrivate::addDecorators(QObject* o, int decoTypes)
 
 void PythonQtPrivate::registerQObjectClassNames(const QStringList& names)
 {
-  for (QString name : names) {
+  for (const QString& name : names) {
     _knownQObjectClassNames.insert(name.toUtf8(), true);
   }
 }
@@ -1616,7 +1616,7 @@ void PythonQt::removeSignalHandlers()
   QList<PythonQtSignalReceiver*> signalReceivers = _p->_signalReceivers.values();
 
   // just delete all signal receivers, they will remove themselves via removeSignalEmitter()
-  for (PythonQtSignalReceiver* receiver : signalReceivers) {
+  for (PythonQtSignalReceiver* receiver : qAsConst(signalReceivers)) {
     delete receiver;
   }
   // just to be sure, clear the receiver map as well
@@ -1747,7 +1747,7 @@ void PythonQt::overwriteSysPath(const QStringList& paths)
   // Since Python uses os.path.sep at various places,
   // makse sure that we use the native path separators.
   QStringList nativePaths;
-  for (QString path : paths) {
+  for (const QString& path : paths) {
     nativePaths << QDir::toNativeSeparators(path);
   }
   PyModule_AddObject(sys, "path", PythonQtConv::QStringListToPyList(nativePaths));
@@ -2181,7 +2181,7 @@ PyObject* PythonQt::helpCalled(PythonQtClassInfo* info)
 
 void PythonQt::clearNotFoundCachedMembers()
 {
-  for (PythonQtClassInfo* info : _p->_knownClassInfos) {
+  for (PythonQtClassInfo* info : qAsConst(_p->_knownClassInfos)) {
     info->clearNotFoundCachedMembers();
   }
 }
@@ -2310,7 +2310,7 @@ const QMetaObject* PythonQtPrivate::buildDynamicMetaObject(PythonQtClassWrapper*
       PythonQtSignalFunctionObject* signal = (PythonQtSignalFunctionObject*)value;
       if (signal->_dynamicInfo) {
         signal->_dynamicInfo->name = PyString_AsString(key);
-        for (QByteArray sig : signal->_dynamicInfo->signatures) {
+        for (const QByteArray& sig : qAsConst(signal->_dynamicInfo->signatures)) {
           builder.addSignal(signal->_dynamicInfo->name + "(" + sig + ")");
           needsMetaObject = true;
         }

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -86,7 +86,7 @@ PythonQtClassInfo::~PythonQtClassInfo()
   if (_destructor) {
     _destructor->deleteOverloadsAndThis();
   }
-  Q_FOREACH(PythonQtSlotInfo* info, _decoratorSlots) {
+  for (PythonQtSlotInfo* info : _decoratorSlots) {
     info->deleteOverloadsAndThis();
   }
 }
@@ -178,7 +178,7 @@ bool PythonQtClassInfo::lookForPropertyAndCache(const char* memberName)
 PythonQtSlotInfo* PythonQtClassInfo::recursiveFindDecoratorSlotsFromDecoratorProvider(const char* memberName, PythonQtSlotInfo* inputInfo, bool &found, QHash<QByteArray, PythonQtMemberInfo>& memberCache, int upcastingOffset)
 {
   inputInfo = findDecoratorSlotsFromDecoratorProvider(memberName, inputInfo, found, memberCache, upcastingOffset);
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     inputInfo = info._parent->recursiveFindDecoratorSlotsFromDecoratorProvider(memberName, inputInfo, found, memberCache, upcastingOffset+info._upcastingOffset);
   }
   return inputInfo;
@@ -330,7 +330,7 @@ PythonQtMemberInfo PythonQtClassInfo::member(const char* memberName)
         // look for dynamic decorators in this class and in derived classes
         QList<QObject*> decoObjects;
         recursiveCollectDecoratorObjects(decoObjects);
-        Q_FOREACH(QObject* deco, decoObjects) {
+        for (QObject* deco : decoObjects) {
           // call on ourself for caching, but with different metaObject():
           found = lookForEnumAndCache(deco->metaObject(), memberName);
           if (found) {
@@ -349,7 +349,7 @@ PythonQtMemberInfo PythonQtClassInfo::member(const char* memberName)
         found = true;
       }
       // maybe it is a nested class?
-      Q_FOREACH(PythonQtClassInfo* nestedClass, _nestedClasses) {
+      for (PythonQtClassInfo* nestedClass : _nestedClasses) {
         PyObject* pyClass = nestedClass->pythonQtClassWrapper();
         if (pyClass) {
           if (strcmp(memberName, nestedClass->unscopedClassName().constData()) == 0) {
@@ -391,14 +391,14 @@ void PythonQtClassInfo::recursiveCollectDecoratorObjects(QList<QObject*>& decora
   if (deco) {
     decoratorObjects.append(deco);
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     info._parent->recursiveCollectDecoratorObjects(decoratorObjects);
   }
 }
 
 void PythonQtClassInfo::recursiveCollectClassInfos(QList<PythonQtClassInfo*>& classInfoObjects) {
   classInfoObjects.append(this);
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     info._parent->recursiveCollectClassInfos(classInfoObjects);
   }
 }
@@ -493,7 +493,7 @@ QStringList PythonQtClassInfo::propertyList()
     }
   }
   QStringList members = memberList();
-  foreach(QString member, members) {
+  for (const QString& member : members) {
     if (member.startsWith("py_get_")) {
       l << member.mid(7);
     }
@@ -524,7 +524,7 @@ QStringList PythonQtClassInfo::memberList()
     // look for dynamic decorators in this class and in derived classes
     QList<PythonQtClassInfo*> infos;
     recursiveCollectClassInfos(infos);
-    Q_FOREACH(PythonQtClassInfo* info, infos) {
+    for (PythonQtClassInfo* info : infos) {
       info->listDecoratorSlotsFromDecoratorProvider(l, false);
     }
   }
@@ -537,11 +537,11 @@ QStringList PythonQtClassInfo::memberList()
   // check enums in the class hierachy of CPP classes
   QList<QObject*> decoObjects;
   recursiveCollectDecoratorObjects(decoObjects);
-  Q_FOREACH(QObject* deco, decoObjects) {
+  for (QObject* deco : decoObjects) {
     enumMetaObjects << deco->metaObject();
   }
   
-  Q_FOREACH(const QMetaObject* meta, enumMetaObjects) {
+  for (const QMetaObject* meta : enumMetaObjects) {
     for (int i = 0; i<meta->enumeratorCount(); i++) {
       QMetaEnum e = meta->enumerator(i);
       l << e.name();
@@ -554,7 +554,7 @@ QStringList PythonQtClassInfo::memberList()
     }
   }
 
-  Q_FOREACH(PythonQtClassInfo* nestedClass, _nestedClasses) {
+  for (PythonQtClassInfo* nestedClass : _nestedClasses) {
     PyObject* pyClass = nestedClass->pythonQtClassWrapper();
     if (pyClass) {
       QByteArray name = nestedClass->unscopedClassName();
@@ -583,7 +583,7 @@ void* PythonQtClassInfo::castTo(void* ptr, const char* classname)
   if (_wrappedClassName == classname) {
     return ptr;
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     void* result = info._parent->castTo((char*)ptr + info._upcastingOffset, classname);
     if (result) {
       return result;
@@ -597,7 +597,7 @@ bool PythonQtClassInfo::inherits(const char* name)
   if (_wrappedClassName == name) {
     return true;
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     if (info._parent->inherits(name)) {
       return true;
     }
@@ -610,7 +610,7 @@ bool PythonQtClassInfo::inherits(PythonQtClassInfo* classInfo)
   if (classInfo == this) {
     return true;
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     if (info._parent->inherits(classInfo)) {
       return true;
     }
@@ -767,14 +767,14 @@ QObject* PythonQtClassInfo::decorator()
 void* PythonQtClassInfo::recursiveCastDownIfPossible(void* ptr, const char** resultClassName)
 {
   if (!_polymorphicHandlers.isEmpty()) {
-    Q_FOREACH(PythonQtPolymorphicHandlerCB* cb, _polymorphicHandlers) {
+    for (PythonQtPolymorphicHandlerCB* cb : _polymorphicHandlers) {
       void* resultPtr = (*cb)(ptr, resultClassName);
       if (resultPtr) {
         return resultPtr;
       }
     }
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     if (!info._parent->isQObject()) {
       void* resultPtr = info._parent->recursiveCastDownIfPossible((char*)ptr + info._upcastingOffset, resultClassName);
       if (resultPtr) {
@@ -818,7 +818,7 @@ void* PythonQtClassInfo::castDownIfPossible(void* ptr, PythonQtClassInfo** resul
   // we only do downcasting on the base object, not on the whole inheritance tree...
   void* resultPtr = nullptr;
   if (!_polymorphicHandlers.isEmpty()) {
-    Q_FOREACH(PythonQtPolymorphicHandlerCB* cb, _polymorphicHandlers) {
+    for (PythonQtPolymorphicHandlerCB* cb : _polymorphicHandlers) {
       resultPtr = (*cb)(ptr, &className);
       if (resultPtr) {
         break;
@@ -897,7 +897,7 @@ void PythonQtClassInfo::createEnumWrappers(const QObject* decoratorProvider)
     if (decoratorProvider) {
       createEnumWrappers(decoratorProvider->metaObject());
     }
-    Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+    for (const ParentClassInfo& info : _parentClasses) {
       // trigger decorator() instead of createEnumWrappers(),
       // which will then call createEnumWrappers().
       info._parent->decorator();
@@ -912,13 +912,13 @@ PyObject* PythonQtClassInfo::findEnumWrapper(const char* name) {
     // which will then call createEnumWrappers().
     decorator();
   }
-  Q_FOREACH(const PythonQtObjectPtr& p, _enumWrappers) {
+  for (const PythonQtObjectPtr& p : _enumWrappers) {
     const char* className = ((PyTypeObject*)p.object())->tp_name;
     if (qstrcmp(className, name)==0) {
       return p.object();
     }
   }
-  Q_FOREACH(const ParentClassInfo& info, _parentClasses) {
+  for (const ParentClassInfo& info : _parentClasses) {
     PyObject* p = info._parent->findEnumWrapper(name);
     if (p) return p;
   }
@@ -1111,7 +1111,7 @@ bool PythonQtClassInfo::supportsRichCompare()
       names << "__gt__";
       names << "__ge__";
     }
-    foreach (const QByteArray& name, names) {
+    for (const QByteArray& name : names) {
       if (member(name)._type == PythonQtMemberInfo::Slot) {
         // we found one of the operators, so we can support the type slot
         _typeSlots |= PythonQt::Type_RichCompare;

--- a/src/PythonQtClassInfo.cpp
+++ b/src/PythonQtClassInfo.cpp
@@ -1111,7 +1111,7 @@ bool PythonQtClassInfo::supportsRichCompare()
       names << "__gt__";
       names << "__ge__";
     }
-    for (const QByteArray& name : names) {
+    for (const QByteArray& name : qAsConst(names)) {
       if (member(name)._type == PythonQtMemberInfo::Slot) {
         // we found one of the operators, so we can support the type slot
         _typeSlots |= PythonQt::Type_RichCompare;

--- a/src/PythonQtClassWrapper.cpp
+++ b/src/PythonQtClassWrapper.cpp
@@ -473,7 +473,7 @@ static PyObject *PythonQtClassWrapper_getattro(PyObject *obj, PyObject *name)
     QSet<QString> completeSet = QSet<QString>::fromList(members);
     completeSet.unite(QSet<QString>::fromList(properties));
 #endif
-    for (QString name : completeSet) {
+    for (const QString& name : qAsConst(completeSet)) {
       if (name.startsWith("py_")) {
         // do not expose internal slots
         continue;

--- a/src/PythonQtClassWrapper.cpp
+++ b/src/PythonQtClassWrapper.cpp
@@ -473,7 +473,7 @@ static PyObject *PythonQtClassWrapper_getattro(PyObject *obj, PyObject *name)
     QSet<QString> completeSet = QSet<QString>::fromList(members);
     completeSet.unite(QSet<QString>::fromList(properties));
 #endif
-    Q_FOREACH (QString name, completeSet) {
+    for (QString name : completeSet) {
       if (name.startsWith("py_")) {
         // do not expose internal slots
         continue;

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -1308,7 +1308,7 @@ PyObject* PythonQtConv::QStringListToPyObject(const QStringList& list)
   PyObject* result = PyTuple_New(list.count());
   int i = 0;
 
-  for (QString str : list) {
+  for (const QString& str : list) {
     PyTuple_SET_ITEM(result, i, PythonQtConv::QStringToPyObject(str));
     i++;
   }
@@ -1373,7 +1373,7 @@ PyObject* PythonQtConv::QVariantHashToPyObject(const QVariantHash& m) {
 PyObject* PythonQtConv::QVariantListToPyObject(const QVariantList& l) {
   PyObject* result = PyTuple_New(l.count());
   int i = 0;
-  for (QVariant v : l) {
+  for (const QVariant& v : l) {
     PyTuple_SET_ITEM(result, i, PythonQtConv::QVariantToPyObject(v));
     i++;
   }
@@ -1386,7 +1386,7 @@ PyObject* PythonQtConv::ConvertQListOfPointerTypeToPythonList(QList<void*>* list
 {
   PyObject* result = PyTuple_New(list->count());
   int i = 0;
-  for (void* value : *list) {
+  for (void* value : qAsConst(*list)) {
     PyObject* wrap = PythonQt::priv()->wrapPtr(value, info.innerName);
     if (wrap) {
       PythonQtInstanceWrapper* wrapper = (PythonQtInstanceWrapper*)wrap;

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -1307,8 +1307,8 @@ PyObject* PythonQtConv::QStringListToPyObject(const QStringList& list)
 {
   PyObject* result = PyTuple_New(list.count());
   int i = 0;
-  QString str;
-  Q_FOREACH (str, list) {
+
+  for (QString str : list) {
     PyTuple_SET_ITEM(result, i, PythonQtConv::QStringToPyObject(str));
     i++;
   }
@@ -1373,8 +1373,7 @@ PyObject* PythonQtConv::QVariantHashToPyObject(const QVariantHash& m) {
 PyObject* PythonQtConv::QVariantListToPyObject(const QVariantList& l) {
   PyObject* result = PyTuple_New(l.count());
   int i = 0;
-  QVariant v;
-  Q_FOREACH (v, l) {
+  for (QVariant v : l) {
     PyTuple_SET_ITEM(result, i, PythonQtConv::QVariantToPyObject(v));
     i++;
   }
@@ -1387,7 +1386,7 @@ PyObject* PythonQtConv::ConvertQListOfPointerTypeToPythonList(QList<void*>* list
 {
   PyObject* result = PyTuple_New(list->count());
   int i = 0;
-  Q_FOREACH (void* value, *list) {
+  for (void* value : *list) {
     PyObject* wrap = PythonQt::priv()->wrapPtr(value, info.innerName);
     if (wrap) {
       PythonQtInstanceWrapper* wrapper = (PythonQtInstanceWrapper*)wrap;

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -243,7 +243,7 @@ PyObject* PythonQtConvertListOfValueTypeToPythonList(const void* /*QList<T>* */ 
   }
   PyObject* result = PyTuple_New(list->size());
   int i = 0;
-  Q_FOREACH (const T& value, *list) {
+  for (const T& value : *list) {
     PyTuple_SET_ITEM(result, i, PythonQtConv::convertQtValueToPythonInternal(innerType, &value));
     i++;
   }
@@ -293,7 +293,7 @@ PyObject* PythonQtConvertListOfKnownClassToPythonList(const void* /*QList<T>* */
   }
   PyObject* result = PyTuple_New(list->size());
   int i = 0;
-  Q_FOREACH(const T& value, *list) {
+  for (const T& value : *list) {
     T* newObject = new T(value);
     PythonQtInstanceWrapper* wrap = (PythonQtInstanceWrapper*)PythonQt::priv()->wrapPtr(newObject, innerType->className());
     wrap->_ownedByPythonQt = true;
@@ -423,7 +423,7 @@ PyObject* PythonQtConvertListOfPairToPythonList(const void* /*QList<QPair<T1,T2>
   PyObject* result = PyTuple_New(list->size());
   int i = 0;
   typedef const QPair<T1, T2> Pair;
-  Q_FOREACH(Pair& value, *list) {
+  for (Pair& value : *list) {
     PyObject* object = PythonQtConvertPairToPython<T1, T2>(&value, innerType);
     PyTuple_SET_ITEM(result, i, object);
     i++;

--- a/src/PythonQtImporter.cpp
+++ b/src/PythonQtImporter.cpp
@@ -143,7 +143,7 @@ int PythonQtImporter_init(PythonQtImporter *self, PyObject *args, PyObject * /*k
       return -1;
     } else {
       const QStringList& ignorePaths = PythonQt::self()->getImporterIgnorePaths();
-      for (QString ignorePath : ignorePaths) {
+      for (const QString& ignorePath : ignorePaths) {
         if (path.startsWith(ignorePath)) {
           PyErr_SetString(PythonQtImportError,
             "path ignored");

--- a/src/PythonQtImporter.cpp
+++ b/src/PythonQtImporter.cpp
@@ -101,7 +101,7 @@ PythonQtImport::ModuleInfo PythonQtImport::getModuleInfo(PythonQtImporter* self,
 
   QString test;
   // test if it is a shared library (they have precedence over *.py files and this is used in eggs)
-  Q_FOREACH(const QString& suffix, PythonQt::priv()->sharedLibrarySuffixes()) {
+  for (const QString& suffix : PythonQt::priv( )->sharedLibrarySuffixes()) {
     test = path + suffix;
     if (PythonQt::importInterface()->exists(test)) {
       info.fullPath = test;
@@ -143,7 +143,7 @@ int PythonQtImporter_init(PythonQtImporter *self, PyObject *args, PyObject * /*k
       return -1;
     } else {
       const QStringList& ignorePaths = PythonQt::self()->getImporterIgnorePaths();
-      Q_FOREACH(QString ignorePath, ignorePaths) {
+      for (QString ignorePath : ignorePaths) {
         if (path.startsWith(ignorePath)) {
           PyErr_SetString(PythonQtImportError,
             "path ignored");

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -411,7 +411,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
     if (wrapper->_obj) {
       // we need to replace the properties with their real values...
       QStringList l = wrapper->classInfo()->propertyList();
-      Q_FOREACH (QString name, l) {
+      for (QString name : l) {
         PyObject* o = PyObject_GetAttrString(obj, QStringToPythonConstCharPointer(name));
         if (o) {
           PyDict_SetItemString(dict, QStringToPythonConstCharPointer(name), o);
@@ -422,7 +422,7 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
       }
 
       QList<QByteArray> dynamicProps = wrapper->_obj->dynamicPropertyNames();
-      Q_FOREACH (QByteArray name, dynamicProps) {
+      for (QByteArray name : dynamicProps) {
         PyObject* o = PyObject_GetAttrString(obj, name.data());
         if (o) {
           PyDict_SetItemString(dict, name.data(), o);

--- a/src/PythonQtInstanceWrapper.cpp
+++ b/src/PythonQtInstanceWrapper.cpp
@@ -410,8 +410,8 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
 
     if (wrapper->_obj) {
       // we need to replace the properties with their real values...
-      QStringList l = wrapper->classInfo()->propertyList();
-      for (QString name : l) {
+      const QStringList l = wrapper->classInfo()->propertyList();
+      for (const QString& name : l) {
         PyObject* o = PyObject_GetAttrString(obj, QStringToPythonConstCharPointer(name));
         if (o) {
           PyDict_SetItemString(dict, QStringToPythonConstCharPointer(name), o);
@@ -421,8 +421,8 @@ static PyObject *PythonQtInstanceWrapper_getattro(PyObject *obj,PyObject *name)
         }
       }
 
-      QList<QByteArray> dynamicProps = wrapper->_obj->dynamicPropertyNames();
-      for (QByteArray name : dynamicProps) {
+      const QList<QByteArray> dynamicProps = wrapper->_obj->dynamicPropertyNames();
+      for (const QByteArray& name : dynamicProps) {
         PyObject* o = PyObject_GetAttrString(obj, name.data());
         if (o) {
           PyDict_SetItemString(dict, name.data(), o);

--- a/src/PythonQtMethodInfo.cpp
+++ b/src/PythonQtMethodInfo.cpp
@@ -62,7 +62,7 @@ PythonQtMethodInfo::PythonQtMethodInfo(const QMetaMethod& meta, PythonQtClassInf
   fillParameterInfo(type, QByteArray(meta.typeName()), classInfo);
   _parameters.append(type);
   QList<QByteArray> names = meta.parameterTypes();
-  Q_FOREACH (const QByteArray& name, names) {
+  for (const QByteArray& name : names) {
     fillParameterInfo(type, name, classInfo);
     _parameters.append(type);
   }
@@ -75,7 +75,7 @@ PythonQtMethodInfo::PythonQtMethodInfo(const QByteArray& typeName, const QList<Q
   ParameterInfo type;
   fillParameterInfo(type, typeName, nullptr);
   _parameters.append(type);
-  Q_FOREACH (const QByteArray& name, args) {
+  for (const QByteArray& name : args) {
     fillParameterInfo(type, name, nullptr);
     _parameters.append(type);
   }
@@ -622,7 +622,7 @@ QStringList PythonQtSlotInfo::overloads(bool skipReturnValue) const
     }
     if (slotsWithSameArgs.size() > 1) {
       results << maxArgSlot->fullSignature(skipReturnValue, minSameArgs);
-      foreach(const PythonQtSlotInfo* o, slotsWithSameArgs) {
+      for (const PythonQtSlotInfo* o : slotsWithSameArgs) {
         list.removeOne(o);
       }
     } else {

--- a/src/gui/PythonQtScriptingConsole.cpp
+++ b/src/gui/PythonQtScriptingConsole.cpp
@@ -299,8 +299,8 @@ void PythonQtScriptingConsole::handleTabCompletion()
   if (!lookup.isEmpty() || !compareText.isEmpty()) {
     compareText = compareText.toLower();
     QStringList found;
-    QStringList l = PythonQt::self()->introspection(_context, lookup, PythonQt::Anything);
-    for (QString n : l) {
+    const QStringList l = PythonQt::self()->introspection(_context, lookup, PythonQt::Anything);
+    for (const QString& n : l) {
       if (n.toLower().startsWith(compareText)) {
         found << n;
       }

--- a/src/gui/PythonQtScriptingConsole.cpp
+++ b/src/gui/PythonQtScriptingConsole.cpp
@@ -300,7 +300,7 @@ void PythonQtScriptingConsole::handleTabCompletion()
     compareText = compareText.toLower();
     QStringList found;
     QStringList l = PythonQt::self()->introspection(_context, lookup, PythonQt::Anything);
-    Q_FOREACH (QString n, l) {
+    for (QString n : l) {
       if (n.toLower().startsWith(compareText)) {
         found << n;
       }

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -567,7 +567,7 @@ void PythonQtTestApi::testVariables()
   QSet<QString> s;
   // check that at least these three variables are set
   s << "obj" << "someObject" << "someValue";
-  for (QString value : s) {
+  for (const QString& value : s) {
     QVERIFY(l.indexOf(value)!=-1);
   }
 

--- a/tests/PythonQtTests.cpp
+++ b/tests/PythonQtTests.cpp
@@ -567,7 +567,7 @@ void PythonQtTestApi::testVariables()
   QSet<QString> s;
   // check that at least these three variables are set
   s << "obj" << "someObject" << "someValue";
-  Q_FOREACH (QString value, s) {
+  for (QString value : s) {
     QVERIFY(l.indexOf(value)!=-1);
   }
 


### PR DESCRIPTION
This pull request includes two main changes:
1. Replaces deprecated `foreach` and `Q_FOREACH` macros with C++11 range-based for loops as recommended by Qt 5.7+.
2. Improves const correctness by using `const` references in range-based for loops and other relevant places.
