### PR TITLE
chore: Migrate integer API usage from `PyInt_*` to `PyLong_*` (Python 3)

### DIFF
--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1655,7 +1655,7 @@ int custom_system_exit_exception_handler()
     /* If we failed to dig out the 'code' attribute,
        just let the else clause below print the error. */
   }
-  if (PyInt_Check(value))
+  if (PyLong_Check(value))
     exitcode = (int)PyInt_AsLong(value);
   else {
     PyObject *sys_stderr = PySys_GetObject(const_cast<char*>("stderr"));

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -845,8 +845,8 @@ PyObject* PythonQtPrivate::createNewPythonQtEnumWrapper(const char* enumName, Py
   PyObject* className = PyString_FromString(enumName);
 
   PyObject* baseClasses = PyTuple_New(1);
-  Py_INCREF(&PyInt_Type);
-  PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PyInt_Type);
+  Py_INCREF(&PyLong_Type);
+  PyTuple_SET_ITEM(baseClasses, 0, (PyObject*)&PyLong_Type);
 
   PyObject* module = PyObject_GetAttrString(parentObject, "__module__");
   PyObject* typeDict = PyDict_New();

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -304,7 +304,7 @@ void PythonQt::init(int flags, const QByteArray& pythonQtModuleName)
     };
     
     for (auto i = 0u; i < sizeof(enumValues)/sizeof(int); i++) {
-      PyObject* obj = PyInt_FromLong(enumValues[i]);
+      PyObject* obj = PyLong_FromLong(enumValues[i]);
       if (PyModule_AddObject(pack, enumNames[i], obj) == 0) {
         Py_INCREF(obj);
       }
@@ -2135,7 +2135,7 @@ void PythonQtPrivate::registerGlobalNamespace(const char* typeName, const char* 
       for (int j = 0; j < metaEnum.keyCount(); j++) {
         QByteArray key = PythonQtClassInfo::escapeReservedNames(metaEnum.key(j));
         int value = metaEnum.value(j);
-        PyObject* obj = PyInt_FromLong(value);
+        PyObject* obj = PyLong_FromLong(value);
         addObjectToPackage(obj, key, packageName, package);
       }
     }

--- a/src/PythonQt.cpp
+++ b/src/PythonQt.cpp
@@ -1656,7 +1656,7 @@ int custom_system_exit_exception_handler()
        just let the else clause below print the error. */
   }
   if (PyLong_Check(value))
-    exitcode = (int)PyInt_AsLong(value);
+    exitcode = (int)PyLong_AsLong(value);
   else {
     PyObject *sys_stderr = PySys_GetObject(const_cast<char*>("stderr"));
     if (sys_stderr != nullptr && sys_stderr != Py_None) {

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -156,27 +156,27 @@ PyObject* PythonQtConv::convertQtValueToPythonInternal(int type, const void* dat
   case QMetaType::Void:
     Py_RETURN_NONE;
   case QMetaType::Char:
-    return PyInt_FromLong(*((char*)data));
+    return PyLong_FromLong(*((char*)data));
   case QMetaType::UChar:
-    return PyInt_FromLong(*((unsigned char*)data));
+    return PyLong_FromLong(*((unsigned char*)data));
   case QMetaType::Short:
-    return PyInt_FromLong(*((short*)data));
+    return PyLong_FromLong(*((short*)data));
   case QMetaType::UShort:
-    return PyInt_FromLong(*((unsigned short*)data));
+    return PyLong_FromLong(*((unsigned short*)data));
   case QMetaType::Long:
-    return PyInt_FromLong(*((long*)data));
+    return PyLong_FromLong(*((long*)data));
   case QMetaType::ULong:
     // does not fit into simple int of python
     return PyLong_FromUnsignedLong(*((unsigned long*)data));
   case QMetaType::Bool:
     return PythonQtConv::GetPyBool(*((bool*)data));
   case QMetaType::Int:
-    return PyInt_FromLong(*((int*)data));
+    return PyLong_FromLong(*((int*)data));
   case QMetaType::UInt:
     // does not fit into simple int of python
     return PyLong_FromUnsignedLong(*((unsigned int*)data));
   case QMetaType::QChar:
-    return PyInt_FromLong(*((unsigned short*)data));
+    return PyLong_FromLong(*((unsigned short*)data));
   case QMetaType::Float:
     return PyFloat_FromDouble(*((float*)data));
   case QMetaType::Double:

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -638,7 +638,7 @@ void* PythonQtConv::ConvertPythonToQt(const PythonQtMethodInfo::ParameterInfo& i
            ok = false;
            if ((PyObject*)obj->ob_type == info.enumWrapper) {
              // we have a exact enum type match:
-             val = PyInt_AS_LONG(obj);
+             val = PyLong_AS_LONG(obj);
              ok = true;
            }
            else if (!strict) {
@@ -887,11 +887,11 @@ int PythonQtConv::PyObjGetInt(PyObject* val, bool strict, bool &ok) {
   int d = 0;
   ok = true;
   if (val->ob_type == &PyLong_Type) {
-    d = PyInt_AS_LONG(val);
+    d = PyLong_AS_LONG(val);
   } else if (!strict) {
     if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
-      d = PyInt_AS_LONG(val);
+      d = PyLong_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {
       d = floor(PyFloat_AS_DOUBLE(val));
     } else if (val->ob_type == &PyLong_Type) {
@@ -924,7 +924,7 @@ qint64 PythonQtConv::PyObjGetLongLong(PyObject* val, bool strict, bool &ok) {
   } else if (!strict) {
     if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
-      d = PyInt_AS_LONG(val);
+      d = PyLong_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {
       d = floor(PyFloat_AS_DOUBLE(val));
     } else if (val == Py_False) {
@@ -954,7 +954,7 @@ quint64 PythonQtConv::PyObjGetULongLong(PyObject* val, bool strict, bool &ok) {
   } else if (!strict) {
     if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
-      d = PyInt_AS_LONG(val);
+      d = PyLong_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {
       d = floor(PyFloat_AS_DOUBLE(val));
     } else if (val == Py_False) {

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -313,7 +313,7 @@ void* PythonQtConv::handlePythonToQtAutoConversion(int typeId, PyObject* obj, vo
   if (typeId == cursorId) {
     static PyObject* qtCursorShapeEnum = PythonQtClassInfo::findEnumWrapper("Qt::CursorShape", nullptr);
     if ((PyObject*)obj->ob_type == qtCursorShapeEnum) {
-      Qt::CursorShape val = (Qt::CursorShape)PyInt_AsLong(obj);
+      Qt::CursorShape val = (Qt::CursorShape)PyLong_AsLong(obj);
       if (!ptr) {
         PythonQtArgumentFrame_ADD_VARIANT_VALUE(frame, QCursor(), ptr);
         ptr = (void*)((QVariant*)ptr)->constData();
@@ -325,7 +325,7 @@ void* PythonQtConv::handlePythonToQtAutoConversion(int typeId, PyObject* obj, vo
     // brushes can be created from QColor and from Qt::GlobalColor (and from brushes, but that's the default)
     static PyObject* qtColorClass = PythonQt::priv()->getClassInfo("QColor")->pythonQtClassWrapper();
     if ((PyObject*)obj->ob_type == qtGlobalColorEnum) {
-      Qt::GlobalColor val = (Qt::GlobalColor)PyInt_AsLong(obj);
+      Qt::GlobalColor val = (Qt::GlobalColor)PyLong_AsLong(obj);
       if (!ptr) {
         PythonQtArgumentFrame_ADD_VARIANT_VALUE(frame, QPen(), ptr);
         ptr = (void*)((QVariant*)ptr)->constData();
@@ -344,7 +344,7 @@ void* PythonQtConv::handlePythonToQtAutoConversion(int typeId, PyObject* obj, vo
     // brushes can be created from QColor and from Qt::GlobalColor (and from brushes, but that's the default)
     static PyObject* qtColorClass = PythonQt::priv()->getClassInfo("QColor")->pythonQtClassWrapper();
     if ((PyObject*)obj->ob_type == qtGlobalColorEnum) {
-      Qt::GlobalColor val = (Qt::GlobalColor)PyInt_AsLong(obj);
+      Qt::GlobalColor val = (Qt::GlobalColor)PyLong_AsLong(obj);
       if (!ptr) {
         PythonQtArgumentFrame_ADD_VARIANT_VALUE(frame, QBrush(), ptr);
         ptr = (void*)((QVariant*)ptr)->constData();
@@ -362,7 +362,7 @@ void* PythonQtConv::handlePythonToQtAutoConversion(int typeId, PyObject* obj, vo
   } else if (typeId == colorId) {
     // colors can be created from Qt::GlobalColor (and from colors, but that's the default)
     if ((PyObject*)obj->ob_type == qtGlobalColorEnum) {
-      Qt::GlobalColor val = (Qt::GlobalColor)PyInt_AsLong(obj);
+      Qt::GlobalColor val = (Qt::GlobalColor)PyLong_AsLong(obj);
       if (!ptr) {
         PythonQtArgumentFrame_ADD_VARIANT_VALUE(frame, QColor(), ptr);
         ptr = (void*)((QVariant*)ptr)->constData();
@@ -903,8 +903,8 @@ int PythonQtConv::PyObjGetInt(PyObject* val, bool strict, bool &ok) {
       d = 1;
     } else {
       PyErr_Clear();
-      // PyInt_AsLong will try conversion to an int if the object is not an int:
-      d = PyInt_AsLong(val);
+      // PyLong_AsLong will try conversion to an int if the object is not an int:
+      d = PyLong_AsLong(val);
       if (PyErr_Occurred()) {
         ok = false;
         PyErr_Clear();

--- a/src/PythonQtConversion.cpp
+++ b/src/PythonQtConversion.cpp
@@ -886,10 +886,10 @@ bool PythonQtConv::PyObjGetBool(PyObject* val, bool strict, bool &ok) {
 int PythonQtConv::PyObjGetInt(PyObject* val, bool strict, bool &ok) {
   int d = 0;
   ok = true;
-  if (val->ob_type == &PyInt_Type) {
+  if (val->ob_type == &PyLong_Type) {
     d = PyInt_AS_LONG(val);
   } else if (!strict) {
-    if (PyObject_TypeCheck(val, &PyInt_Type)) {
+    if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
       d = PyInt_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {
@@ -922,7 +922,7 @@ qint64 PythonQtConv::PyObjGetLongLong(PyObject* val, bool strict, bool &ok) {
   if (val->ob_type == &PyLong_Type) {
     d = PyLong_AsLongLong(val);
   } else if (!strict) {
-    if (PyObject_TypeCheck(val, &PyInt_Type)) {
+    if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
       d = PyInt_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {
@@ -952,7 +952,7 @@ quint64 PythonQtConv::PyObjGetULongLong(PyObject* val, bool strict, bool &ok) {
   if (Py_TYPE(val) == &PyLong_Type) {
     d = PyLong_AsUnsignedLongLong(val);
   } else if (!strict) {
-    if (PyObject_TypeCheck(val, &PyInt_Type)) {
+    if (PyObject_TypeCheck(val, &PyLong_Type)) {
       // support for derived int classes, e.g. for our enums
       d = PyInt_AS_LONG(val);
     } else if (val->ob_type == &PyFloat_Type) {

--- a/src/PythonQtConversion.h
+++ b/src/PythonQtConversion.h
@@ -483,7 +483,7 @@ PyObject* PythonQtConvertIntegerMapToPython(const void* /*QMap<int, T>* */ inMap
   PyObject* key;
   PyObject* val;
   for (; t != map->constEnd(); t++) {
-    key = PyInt_FromLong(t.key());
+    key = PyLong_FromLong(t.key());
     val = PythonQtConv::convertQtValueToPythonInternal(innerType, &t.value());
     PyDict_SetItem(result, key, val);
     Py_DECREF(key);

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -126,7 +126,6 @@
 #define PyString_FromFormat PyUnicode_FromFormat
 #define PyString_Check      PyUnicode_Check
 
-#define PyInt_Check    PyLong_Check
 #define PyInt_AsLong   PyLong_AsLong
 
 #else

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -126,7 +126,6 @@
 #define PyString_FromFormat PyUnicode_FromFormat
 #define PyString_Check      PyUnicode_Check
 
-#define PyInt_AS_LONG  PyLong_AS_LONG
 #define PyInt_Check    PyLong_Check
 #define PyInt_AsLong   PyLong_AsLong
 

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -126,7 +126,6 @@
 #define PyString_FromFormat PyUnicode_FromFormat
 #define PyString_Check      PyUnicode_Check
 
-#define PyInt_Type     PyLong_Type
 #define PyInt_FromLong PyLong_FromLong
 #define PyInt_AS_LONG  PyLong_AS_LONG
 #define PyInt_Check    PyLong_Check

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -126,7 +126,6 @@
 #define PyString_FromFormat PyUnicode_FromFormat
 #define PyString_Check      PyUnicode_Check
 
-#define PyInt_FromLong PyLong_FromLong
 #define PyInt_AS_LONG  PyLong_AS_LONG
 #define PyInt_Check    PyLong_Check
 #define PyInt_AsLong   PyLong_AsLong

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -126,8 +126,6 @@
 #define PyString_FromFormat PyUnicode_FromFormat
 #define PyString_Check      PyUnicode_Check
 
-#define PyInt_AsLong   PyLong_AsLong
-
 #else
 // Defines to use Python 3 names in Python 2 code
 #define PyBytes_Type      PyString_Type


### PR DESCRIPTION
This PR replaces remaining `PyInt_*` usages with the Python 3 `PyLong_*` equivalents.