### PR TITLE
Rename master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build
 on:
   push:
     branches: 
-      - master
+      - main
   pull_request:
-   
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -3,7 +3,7 @@ name: Check generated_cpp
 on:
   push:
     branches: 
-       - master
+       - main
   pull_request:
 
 concurrency:

--- a/.github/workflows/builddocs.yml
+++ b/.github/workflows/builddocs.yml
@@ -3,7 +3,7 @@ name: Build and Deploy Documentation
 on:
   push:
     branches: 
-      - master
+      - main
 
 defaults:
   run:
@@ -13,7 +13,7 @@ jobs:
   build_docs:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v5
 
       - name: Install Doxygen

--- a/src/PythonQtDoc.h
+++ b/src/PythonQtDoc.h
@@ -132,12 +132,12 @@ Qt framework</a>.
  PythonQt supports:
  - Python 2 (>= Python 2.7)
  - Python 3 (>= Python 3.6)
- - Qt 4.x (Qt 4.7 and Qt 4.8 recommended) (not in the master branch, see below)
+ - Qt 4.x (Qt 4.7 and Qt 4.8 recommended) (not in the main branch, see below)
  - Qt 5.x (Tested with Qt 5.6, 5.11, 5.12 and 5.15)
  - Qt 6.x (Tested with Qt 6.5 - 6.7) - support may not be complete, support for optional modules may be added as needed
 
  The last working Qt4 version is available at svn branches/Qt4LastWorkingVersion or you can download the PythonQt 3.0 release.
- The current git master branch no longer supports Qt4, since we started to make use of some Qt5-only features.
+ The current git main branch no longer supports Qt4, since we started to make use of some Qt5-only features.
 
  \section Comparison Comparison with PySide
 


### PR DESCRIPTION
- the branch itself has already been renamed, this only adapts the workflows
- see #144

Closes #144.