### PR TITLE
chore(generator): Fix deprecated QFlags default constructor warning

### DIFF
--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -794,6 +794,7 @@ class ComplexTypeEntry : public TypeEntry
 {
 public:
     enum TypeFlag {
+        NoTypeFlags        = 0x0,
         ForceAbstract      = 0x1,
         DeleteInMainThread = 0x2,
         Deprecated         = 0x4
@@ -809,7 +810,7 @@ public:
           m_createShell(false),
           m_createPromoter(false),
           m_noCopy(false),
-          m_type_flags(0)
+          m_type_flags(TypeFlag::NoTypeFlags)
     {
         Include inc;
         inc.name = "QVariant";


### PR DESCRIPTION
This changes the initialization of `m_type_flags` to use `TypeFlag::NoTypeFlags` instead of 0. This resolves a deprecation warning related to the QFlags default constructor in Qt 5.15.2.

The warning fixed is:

```
/path/to/PythonQt/generator/typesystem.h:812:11: warning: ‘constexpr QFlags<T>::QFlags(QFlags<T>::Zero) [with Enum = ComplexTypeEntry::TypeFlag; QFlags<T>::Zero = int QFlags<ComplexTypeEntry::TypeFlag>::Private::*]’ is deprecated: Use default constructor instead [-Wdeprecated-declarations]
  812 |           m_type_flags(0)
      |           ^~~~~~~~~~~~~~~
In file included from /path/to/Qt/5.15.2/gcc_64/include/QtCore/qglobal.h:1304,
                 from /path/to/Qt/5.15.2/gcc_64/include/QtCore/qalgorithms.h:43,
                 from /path/to/Qt/5.15.2/gcc_64/include/QtCore/qlist.h:43,
                 from /path/to/Qt/5.15.2/gcc_64/include/QtCore/QList:1,
                 from /path/to/PythonQt/generator/parser/codemodel_fwd.h:46,
                 from /path/to/PythonQt/generator/parser/codemodel.h:46,
                 from /path/to/PythonQt/generator/abstractmetabuilder.h:45,
                 from /path/to/PythonQt/generator/abstractmetabuilder.cpp:42:
/path/to/Qt/5.15.2/gcc_64/include/QtCore/qflags.h:123:80: note: declared here
  123 |     QT_DEPRECATED_X("Use default constructor instead") Q_DECL_CONSTEXPR inline QFlags(Zero) noexcept : i(0) {}
      |                                                                                ^~~~~~
```