### PR TITLE
chore(generator): Replace deprecated use of "endl" with "Qt::endl"

### DIFF
--- a/generator/abstractmetabuilder.cpp
+++ b/generator/abstractmetabuilder.cpp
@@ -2396,7 +2396,7 @@ static void write_reject_log_file(const QString &name, const QString &tagName,
 
 
     for (int reason=0; reason<AbstractMetaBuilder::NoReason; ++reason) {
-        s << QString(72, '*') << endl;
+        s << QString(72, '*') << Qt::endl;
         switch (reason) {
         case AbstractMetaBuilder::NotInTypeSystem:
             s << "Not in type system";
@@ -2421,21 +2421,21 @@ static void write_reject_log_file(const QString &name, const QString &tagName,
             break;
         }
 
-        s << endl;
+        s << Qt::endl;
 
         for (QMap<QString, AbstractMetaBuilder::RejectReason>::const_iterator it = rejects.constBegin();
              it != rejects.constEnd(); ++it) {
             if (it.value() != reason)
                 continue;
             if (tagName.isEmpty()) {
-              s << it.key() << endl;
+              s << it.key() << Qt::endl;
             } else {
-              s << "<" << tagName << " name=\"" << it.key() << "\"/>" << endl;
-//              s << "<rejection class=\"" << it.key() << "\"/>" << endl;
+              s << "<" << tagName << " name=\"" << it.key() << "\"/>" << Qt::endl;
+//              s << "<rejection class=\"" << it.key() << "\"/>" << Qt::endl;
             }
         }
 
-        s << QString(72, '*') << endl << endl;
+        s << QString(72, '*') << Qt::endl << Qt::endl;
     }
 
 }

--- a/generator/generator.cpp
+++ b/generator/generator.cpp
@@ -91,7 +91,7 @@ void Generator::printClasses()
         if (!shouldGenerate(cls))
             continue;
         write(s, cls);
-        s << endl << endl;
+        s << Qt::endl << Qt::endl;
     }
 }
 

--- a/generator/setupgenerator.cpp
+++ b/generator/setupgenerator.cpp
@@ -277,18 +277,18 @@ void SetupGenerator::generate()
       ReportHandler::debugSparse(QString("generating: %1").arg(fileName));
       QTextStream &s = initFile.stream;
 
-      s << "#include <PythonQt.h>" << endl;
-      s << "#include <PythonQtConversion.h>" << endl;
+      s << "#include <PythonQt.h>" << Qt::endl;
+      s << "#include <PythonQtConversion.h>" << Qt::endl;
 
       for (int i=0; i<(list.count()+ maxClassesPerFile -1) / maxClassesPerFile; i++) {
-        s << "#include \"" << packKey << QString::number(i) << ".h\"" << endl;
+        s << "#include \"" << packKey << QString::number(i) << ".h\"" << Qt::endl;
       }
-      s << endl;
+      s << Qt::endl;
 
       QStringList polymorphicHandlers;
       if (!isBuiltin) {
         polymorphicHandlers = writePolymorphicHandler(s, list.at(0)->package(), classes_with_polymorphic_id, list);
-        s << endl;
+        s << Qt::endl;
       }
 
       QSet<QString> listRegistration;
@@ -320,14 +320,14 @@ void SetupGenerator::generate()
       for (QString snip :  snips) {
         s << snip;
       }
-      s << endl;
+      s << Qt::endl;
 
       // declare individual class creation functions
-      s << "void PythonQt_init_" << initName << "(PyObject* module) {" << endl;
+      s << "void PythonQt_init_" << initName << "(PyObject* module) {" << Qt::endl;
 
       for (const AbstractMetaClass* cls : list) {
         if (cls->qualifiedCppName().contains("Ssl")) {
-          s << "#ifndef QT_NO_SSL"  << endl;
+          s << "#ifndef QT_NO_SSL"  << Qt::endl;
         }
         AbstractMetaFunctionList ctors = cls->queryFunctions(AbstractMetaClass::Constructors
           | AbstractMetaClass::WasVisible
@@ -358,28 +358,28 @@ void SetupGenerator::generate()
           operatorCodes = "0";
         }
         if (cls->isQObject()) {
-          s << "PythonQt::priv()->registerClass(&" << cls->qualifiedCppName() << "::staticMetaObject, \"" << packageName <<"\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">" << shellCreator << ", module, " << operatorCodes <<");" << endl;
+          s << "PythonQt::priv()->registerClass(&" << cls->qualifiedCppName() << "::staticMetaObject, \"" << packageName <<"\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">" << shellCreator << ", module, " << operatorCodes <<");" << Qt::endl;
         } else if (cls->isGlobalNamespace()) {
-          s << "PythonQt::priv()->registerGlobalNamespace(\"" << cls->qualifiedCppName() << "\", \"" << packageName << "\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">, PythonQtWrapper_" << cls->name() << "::staticMetaObject, module); " << endl;
+          s << "PythonQt::priv()->registerGlobalNamespace(\"" << cls->qualifiedCppName() << "\", \"" << packageName << "\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">, PythonQtWrapper_" << cls->name() << "::staticMetaObject, module); " << Qt::endl;
         } else {
           QString baseName = cls->baseClass()?cls->baseClass()->qualifiedCppName():"";
-          s << "PythonQt::priv()->registerCPPClass(\""<< cls->qualifiedCppName() << "\", \"" << baseName << "\", \"" << packageName <<"\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">" << shellCreator << ", module, " << operatorCodes <<");" << endl;
+          s << "PythonQt::priv()->registerCPPClass(\""<< cls->qualifiedCppName() << "\", \"" << baseName << "\", \"" << packageName <<"\", PythonQtCreateObject<PythonQtWrapper_" << cls->name() << ">" << shellCreator << ", module, " << operatorCodes <<");" << Qt::endl;
         }
         for (AbstractMetaClass* interface :  cls->interfaces()) {
           // the interface might be our own class... (e.g. QPaintDevice)
           if (interface->qualifiedCppName() != cls->qualifiedCppName()) {
-            s << "PythonQt::self()->addParentClass(\""<< cls->qualifiedCppName() << "\", \"" << interface->qualifiedCppName() << "\",PythonQtUpcastingOffset<" << cls->qualifiedCppName() <<","<<interface->qualifiedCppName()<<">());" << endl;
+            s << "PythonQt::self()->addParentClass(\""<< cls->qualifiedCppName() << "\", \"" << interface->qualifiedCppName() << "\",PythonQtUpcastingOffset<" << cls->qualifiedCppName() <<","<<interface->qualifiedCppName()<<">());" << Qt::endl;
           }
         }
         if (cls->qualifiedCppName().contains("Ssl")) {
-          s << "#endif"  << endl;
+          s << "#endif"  << Qt::endl;
         }
       }
-      s << endl;
+      s << Qt::endl;
       for (QString handler : polymorphicHandlers) {
-        s << "PythonQt::self()->addPolymorphicHandler(\""<< handler << "\", polymorphichandler_" << handler << ");" << endl;
+        s << "PythonQt::self()->addPolymorphicHandler(\""<< handler << "\", polymorphichandler_" << handler << ");" << Qt::endl;
       }
-      s << endl;
+      s << Qt::endl;
 
 #if QT_VERSION < QT_VERSION_CHECK(5,14,0)
       QStringList list = listRegistration.toList();
@@ -389,16 +389,16 @@ void SetupGenerator::generate()
       list.sort();
       for(auto &&name: list) {
         if (name.contains("Ssl")) {
-          s << "#ifndef QT_NO_SSL" << endl;
+          s << "#ifndef QT_NO_SSL" << Qt::endl;
         }
-        s << name << endl;
+        s << name << Qt::endl;
         if (name.contains("Ssl")) {
-          s << "#endif" << endl;
+          s << "#endif" << Qt::endl;
         }
       }
 
       s << "}";
-      s << endl;
+      s << Qt::endl;
     }
   }
 }
@@ -440,21 +440,21 @@ QStringList SetupGenerator::writePolymorphicHandler(QTextStream &s, const QStrin
             handlers.append(handler);
 
             s << "static void* polymorphichandler_" << handler
-              << "(const void *ptr, const char **class_name)" << endl
-              << "{" << endl
-              << "    Q_ASSERT(ptr != nullptr);" << endl
+              << "(const void *ptr, const char **class_name)" << Qt::endl
+              << "{" << Qt::endl
+              << "    Q_ASSERT(ptr != nullptr);" << Qt::endl
               << "    " << cls->qualifiedCppName() << " *object = ("
-              << cls->qualifiedCppName() << " *)ptr;" << endl;
+              << cls->qualifiedCppName() << " *)ptr;" << Qt::endl;
           }
 
           // For each, add case label
           QString polyId = clazz->typeEntry()->polymorphicIdValue();
           s << "    if ("
             << polyId.replace("%1", "object")
-            << ") {" << endl
-            << "        *class_name = \"" << clazz->name() << "\";" << endl
-            << "        return (" << clazz->qualifiedCppName() << "*)object;" << endl
-            << "    }" << endl;
+            << ") {" << Qt::endl
+            << "        *class_name = \"" << clazz->name() << "\";" << Qt::endl
+            << "        return (" << clazz->qualifiedCppName() << "*)object;" << Qt::endl
+            << "    }" << Qt::endl;
         } else {
           QString warning = QString("class '%1' inherits from polymorphic class '%2', but has no polymorphic id set")
             .arg(clazz->name())
@@ -467,8 +467,8 @@ QStringList SetupGenerator::writePolymorphicHandler(QTextStream &s, const QStrin
 
     // Close the function if it has been opened
     if (!first) {
-      s << "    return nullptr;" << endl
-        << "}" << endl;
+      s << "    return nullptr;" << Qt::endl
+        << "}" << Qt::endl;
     }
   }
 

--- a/generator/shellgenerator.cpp
+++ b/generator/shellgenerator.cpp
@@ -432,7 +432,7 @@ void ShellGenerator::writeInclude(QTextStream &stream, const Include &inc)
     stream << ">";
   else
     stream << "\"";
-  stream << endl;
+  stream << Qt::endl;
 }
 
 const AbstractMetaClass* ShellGenerator::setCurrentScope(const AbstractMetaClass* scope)

--- a/generator/shellheadergenerator.cpp
+++ b/generator/shellheadergenerator.cpp
@@ -109,21 +109,21 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
 
   QString include_block = "PYTHONQTWRAPPER_" + meta_class->name().toUpper() + "_H";
 
-  s << "#ifndef " << include_block << endl
-    << "#define " << include_block << endl << endl;
+  s << "#ifndef " << include_block << Qt::endl
+    << "#define " << include_block << Qt::endl << Qt::endl;
 
   Include inc = meta_class->typeEntry()->include();
   ShellGenerator::writeInclude(s, inc);
 
-  s << "#include <QObject>" << endl << endl;
-  s << "#include <PythonQt.h>" << endl << endl;
+  s << "#include <QObject>" << Qt::endl << Qt::endl;
+  s << "#include <PythonQt.h>" << Qt::endl << Qt::endl;
 
   IncludeList list = meta_class->typeEntry()->extraIncludes();
   std::sort(list.begin(), list.end());
   for (const Include & inc :  list) {
     ShellGenerator::writeInclude(s, inc);
   }
-  s << endl;
+  s << Qt::endl;
 
 
   AbstractMetaFunctionList ctors = meta_class->queryFunctions(AbstractMetaClass::Constructors
@@ -131,7 +131,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
     | AbstractMetaClass::NotRemovedFromTargetLang);
 
   if (meta_class->qualifiedCppName().contains("Ssl")) {
-    s << "#ifndef QT_NO_SSL" << endl;
+    s << "#ifndef QT_NO_SSL" << Qt::endl;
   }
 
   // Shell-------------------------------------------------------------------
@@ -140,8 +140,8 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
     AbstractMetaFunctionList virtualsForShell = getVirtualFunctionsForShell(meta_class);
 
     s << "class " << shellClassName(meta_class)
-      << " : public " << meta_class->qualifiedCppName() << endl << "{" << endl;
-    s << "public:" << endl;
+      << " : public " << meta_class->qualifiedCppName() << Qt::endl << "{" << Qt::endl;
+    s << "public:" << Qt::endl;
     for (AbstractMetaFunction * fun :  ctors) {
       s << "    ";
       writeFunctionSignature(s, fun, 0, "PythonQtShell_",
@@ -156,27 +156,27 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       }
       s << "),_wrapper(nullptr) {";
       writeInjectedCode(s, meta_class, TypeSystem::PyInheritShellConstructorCode, true);
-      s << "};" << endl;
+      s << "};" << Qt::endl;
     }
-    s << endl;
-    s << "   ~" << shellClassName(meta_class) << "()" << (meta_class->hasVirtualDestructor() ? " override" : "") << ";" << endl;
-    s << endl;
+    s << Qt::endl;
+    s << "   ~" << shellClassName(meta_class) << "()" << (meta_class->hasVirtualDestructor() ? " override" : "") << ";" << Qt::endl;
+    s << Qt::endl;
 
     for (AbstractMetaFunction * fun :  virtualsForShell) {
       writeFunctionSignature(s, fun, 0, QString(),
         Option(IncludeDefaultExpression | ShowStatic | UnderscoreSpaces));
-      s << " override;" << endl;
+      s << " override;" << Qt::endl;
     }
-    s << endl;
+    s << Qt::endl;
     if (meta_class->isQObject()) {
-      s << "  const QMetaObject* metaObject() const override;" << endl;
-      s << "  int qt_metacall(QMetaObject::Call call, int id, void** args) override;" << endl;
+      s << "  const QMetaObject* metaObject() const override;" << Qt::endl;
+      s << "  int qt_metacall(QMetaObject::Call call, int id, void** args) override;" << Qt::endl;
     }
     writeInjectedCode(s, meta_class, TypeSystem::PyShellDeclaration);
     writeInjectedCode(s, meta_class, TypeSystem::PyInheritShellDeclaration, true);
-    s << "  PythonQtInstanceWrapper* _wrapper;" << endl;
+    s << "  PythonQtInstanceWrapper* _wrapper;" << Qt::endl;
 
-    s << "};" << endl << endl;
+    s << "};" << Qt::endl << Qt::endl;
   }
 
   // Promoter-------------------------------------------------------------------
@@ -186,13 +186,13 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
   }
   if (!promoteFunctions.isEmpty()) {
     s << "class " << promoterClassName(meta_class)
-      << " : public " << meta_class->qualifiedCppName() << endl << "{ public:" << endl;
+      << " : public " << meta_class->qualifiedCppName() << Qt::endl << "{ public:" << Qt::endl;
 
     AbstractMetaEnumList enums1 = meta_class->enums();
     std::sort(enums1.begin(), enums1.end(), enum_lessThan);
     for (AbstractMetaEnum * enum1 :  enums1) {
       if (enum1->wasProtected()) {
-        s << "enum " << enum1->name() << "{" << endl;
+        s << "enum " << enum1->name() << "{" << Qt::endl;
         bool first = true;
         QString scope = meta_class->qualifiedCppName();
         for (AbstractMetaEnumValue * value :  enum1->values()) {
@@ -200,7 +200,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
           else { s << ", "; }
           s << "  " << value->name() << " = " << scope << "::" << value->name();
         }
-        s << "};" << endl;
+        s << "};" << Qt::endl;
       }
     }
 
@@ -230,7 +230,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
         }
         s << fun->originalName() << "(";
         writePromoterArgs(args, s);
-        s << "); }" << endl;
+        s << "); }" << Qt::endl;
       }
     }
 
@@ -256,20 +256,20 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
         }
         s << fun->originalName() << "(";
         writePromoterArgs(args, s);
-        s << "); }" << endl;
+        s << "); }" << Qt::endl;
       }
     }
 
-    s << "};" << endl << endl;
+    s << "};" << Qt::endl << Qt::endl;
   }
 
   // Wrapper-------------------------------------------------------------------
 
   s << "class " << wrapperClassName(meta_class)
-    << " : public QObject" << endl
-    << "{ Q_OBJECT" << endl;
+    << " : public QObject" << Qt::endl
+    << "{ Q_OBJECT" << Qt::endl;
 
-  s << "public:" << endl;
+  s << "public:" << Qt::endl;
 
   AbstractMetaEnumList enums1 = meta_class->enums();
   std::sort(enums1.begin(), enums1.end(), enum_lessThan);
@@ -293,7 +293,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
     for (AbstractMetaEnum * enum1 :  enums) {
       s << enum1->name() << " ";
     }
-    s << ")" << endl;
+    s << ")" << Qt::endl;
 
     if (flags.count()) {
       s << "Q_FLAGS(";
@@ -305,12 +305,12 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
         }
         s << origName << " ";
       }
-      s << ")" << endl;
+      s << ")" << Qt::endl;
     }
 
     for (AbstractMetaEnum * enum1 :  enums) {
       bool isEnumClass = enum1->typeEntry()->isEnumClass();
-      s << "enum " << (isEnumClass ? "class " : "") << enum1->name() << "{" << endl;
+      s << "enum " << (isEnumClass ? "class " : "") << enum1->name() << "{" << Qt::endl;
       bool first = true;
       QString scope = meta_class->isGlobalNamespace() ? QString() :
           (enum1->wasProtected() ? promoterClassName(meta_class) : meta_class->qualifiedCppName());
@@ -330,7 +330,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
 
         }
       }
-      s << "};" << endl;
+      s << "};" << Qt::endl;
     }
     if (flags.count()) {
       for (AbstractMetaEnum * enum1 :  enums) {
@@ -340,12 +340,12 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
           if (idx != -1) {
             origName = origName.mid(idx + 2);
           }
-          s << "Q_DECLARE_FLAGS(" << origName << ", " << enum1->name() << ")" << endl;
+          s << "Q_DECLARE_FLAGS(" << origName << ", " << enum1->name() << ")" << Qt::endl;
         }
       }
     }
   }
-  s << "public Q_SLOTS:" << endl;
+  s << "public Q_SLOTS:" << Qt::endl;
   if (meta_class->generateShellClass() || !meta_class->isAbstract()) {
 
     bool copyConstructorSeen = false;
@@ -356,7 +356,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       s << meta_class->qualifiedCppName() << "* ";
       writeFunctionSignature(s, fun, 0, "new_",
         Option(IncludeDefaultExpression | ShowStatic | AddOwnershipTemplates));
-      s << ";" << endl;
+      s << ";" << Qt::endl;
       if (fun->arguments().size() == 1 && meta_class->qualifiedCppName() == fun->arguments().at(0)->type()->typeEntry()->qualifiedCppName()) {
         copyConstructorSeen = true;
       }
@@ -369,14 +369,14 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       && !copyConstructorSeen && defaultConstructorSeen && !meta_class->typeEntry()->hasNoCopy())
     {
       QString className = meta_class->generateShellClass() ? shellClassName(meta_class) : meta_class->qualifiedCppName();
-      s << meta_class->qualifiedCppName() << "* new_" << meta_class->name() << "(const " << meta_class->qualifiedCppName() << "& other) {" << endl;
-      s << className << "* a = new " << className << "();" << endl;
-      s << "*((" << meta_class->qualifiedCppName() << "*)a) = other;" << endl;
-      s << "return a; }" << endl;
+      s << meta_class->qualifiedCppName() << "* new_" << meta_class->name() << "(const " << meta_class->qualifiedCppName() << "& other) {" << Qt::endl;
+      s << className << "* a = new " << className << "();" << Qt::endl;
+      s << "*((" << meta_class->qualifiedCppName() << "*)a) = other;" << Qt::endl;
+      s << "return a; }" << Qt::endl;
     }
   }
   if (meta_class->hasPublicDestructor() && !meta_class->isNamespace()) {
-    s << "void delete_" << meta_class->name() << "(" << meta_class->qualifiedCppName() << "* obj) { delete obj; }" << endl;
+    s << "void delete_" << meta_class->name() << "(" << meta_class->qualifiedCppName() << "* obj) { delete obj; }" << Qt::endl;
   }
 
   AbstractMetaFunctionList functions = getFunctionsToWrap(meta_class);
@@ -388,7 +388,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
       s << "   ";
       writeFunctionSignature(s, function, 0, QString(),
         Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | IncludeDefaultExpression | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts));
-      s << ";" << endl;
+      s << ";" << Qt::endl;
     }
     if (function->isVirtual() && meta_class->typeEntry()->shouldCreatePromoter()) {
       // qualified version that calls the promoter/the qualified version
@@ -415,11 +415,11 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
         s << args.at(i)->argumentName();
       }
       s << "));";
-      s << "}" << endl;
+      s << "}" << Qt::endl;
     }
   }
   if (meta_class->hasDefaultToStringFunction() || meta_class->hasToStringCapability()) {
-    s << "    QString py_toString(" << meta_class->qualifiedCppName() << "*);" << endl;
+    s << "    QString py_toString(" << meta_class->qualifiedCppName() << "*);" << Qt::endl;
   }
   QString nonZeroFunc = meta_class->getDefaultNonZeroFunction();
   if (!nonZeroFunc.isEmpty()) {
@@ -427,7 +427,7 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
     if (nonZeroFunc != "isValid") {
       s << "!";
     }
-    s << "obj->" << nonZeroFunc << "(); }" << endl;
+    s << "obj->" << nonZeroFunc << "(); }" << Qt::endl;
   }
 
   AbstractMetaFieldList fields = meta_class->fields();
@@ -444,12 +444,12 @@ void ShellHeaderGenerator::write(QTextStream& s, const AbstractMetaClass* meta_c
   writeInjectedCode(s, meta_class, TypeSystem::PyWrapperDeclaration);
 
 
-  s << "};" << endl << endl;
+  s << "};" << Qt::endl << Qt::endl;
   if (meta_class->qualifiedCppName().contains("Ssl")) {
-    s << "#endif" << endl << endl;
+    s << "#endif" << Qt::endl << Qt::endl;
   }
 
-  s << "#endif // " << include_block << endl;
+  s << "#endif // " << include_block << Qt::endl;
 
   setCurrentScope(nullptr);
 }
@@ -477,7 +477,7 @@ void ShellHeaderGenerator::writeInjectedCode(QTextStream& s, const AbstractMetaC
     CodeSnipList code_snips = cls->typeEntry()->codeSnips();
     for (const CodeSnip & cs :  code_snips) {
       if (cs.language == type) {
-        s << cs.code() << endl;
+        s << cs.code() << Qt::endl;
       }
     }
     cls = cls->baseClass();

--- a/generator/shellimplgenerator.cpp
+++ b/generator/shellimplgenerator.cpp
@@ -77,11 +77,11 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   QString pro_file_name = fileBaseName + "/" + fileBaseName + ".pri";
   priGenerator->addSource(pro_file_name, fileNameForClass(meta_class));
   
-  s << "#include \"PythonQtWrapper_" << meta_class->name() << ".h\"" << endl << endl;
+  s << "#include \"PythonQtWrapper_" << meta_class->name() << ".h\"" << Qt::endl << Qt::endl;
 
-  s << "#include <PythonQtSignalReceiver.h>" << endl;
-  s << "#include <PythonQtMethodInfo.h>" << endl;
-  s << "#include <PythonQtConversion.h>" << endl;
+  s << "#include <PythonQtSignalReceiver.h>" << Qt::endl;
+  s << "#include <PythonQtMethodInfo.h>" << Qt::endl;
+  s << "#include <PythonQtConversion.h>" << Qt::endl;
 
   //if (!meta_class->generateShellClass())
   //    return;
@@ -91,7 +91,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   for (const Include& inc : list) {
     ShellGenerator::writeInclude(s, inc);
   }  
-  s << endl;
+  s << Qt::endl;
 
   writeHelperCode(s, meta_class);
 
@@ -107,19 +107,19 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
   {
     //    QSet<QString> registeredTypeNames = m_qmetatype_declared_typenames;
     //    declareFunctionMetaTypes(s, functions, registeredTypeNames);
-    //    s << endl;
+    //    s << Qt::endl;
   }
   if (meta_class->qualifiedCppName().contains("Ssl")) {
-    s << "#ifndef QT_NO_SSL"  << endl;
+    s << "#ifndef QT_NO_SSL"  << Qt::endl;
   }
 
   bool generateShell = meta_class->generateShellClass() && !ctors.isEmpty();
   if (generateShell) {
 
-    s << shellClassName(meta_class) << "::~" << shellClassName(meta_class) << "() {" << endl;
-    s << "  PythonQtPrivate* priv = PythonQt::priv();" << endl;
-    s << "  if (priv) { priv->shellClassDeleted(this); }" << endl;
-    s << "}" << endl;
+    s << shellClassName(meta_class) << "::~" << shellClassName(meta_class) << "() {" << Qt::endl;
+    s << "  PythonQtPrivate* priv = PythonQt::priv();" << Qt::endl;
+    s << "  if (priv) { priv->shellClassDeleted(this); }" << Qt::endl;
+    s << "}" << Qt::endl;
 
     AbstractMetaFunctionList virtualsForShell = getVirtualFunctionsForShell(meta_class);
     for (const AbstractMetaFunction* fun : virtualsForShell) {
@@ -127,7 +127,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
       writeFunctionSignature(s, fun, meta_class, QString(),
         Option(ShowStatic | UnderscoreSpaces | UseIndexedName),
         "PythonQtShell_");
-      s << endl << "{" << endl;
+      s << Qt::endl << "{" << Qt::endl;
 
       Option typeOptions = Option(UnderscoreSpaces | SkipName);
       AbstractMetaArgumentList args = fun->arguments();
@@ -135,12 +135,12 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
       // we can't handle return values which are references right now, do not send those to Python...
       if (!hasReturnValue || !fun->type()->isReference()) {
 
-        s << "if (_wrapper) {" << endl;
-        s << "  PYTHONQT_GIL_SCOPE" << endl;
-        s << "  if (Py_REFCNT((PyObject*)_wrapper) > 0) {" << endl;
-        s << "    static PyObject* name = PyUnicode_FromString(\"" << fun->name() << "\");" << endl;
-        s << "    PyObject* obj = PyBaseObject_Type.tp_getattro((PyObject*)_wrapper, name);" << endl;
-        s << "    if (obj) {" << endl;
+        s << "if (_wrapper) {" << Qt::endl;
+        s << "  PYTHONQT_GIL_SCOPE" << Qt::endl;
+        s << "  if (Py_REFCNT((PyObject*)_wrapper) > 0) {" << Qt::endl;
+        s << "    static PyObject* name = PyUnicode_FromString(\"" << fun->name() << "\");" << Qt::endl;
+        s << "    PyObject* obj = PyBaseObject_Type.tp_getattro((PyObject*)_wrapper, name);" << Qt::endl;
+        s << "    if (obj) {" << Qt::endl;
         s << "      static const char* argumentList[] ={\"";
         if (hasReturnValue) {
           // write the arguments, return type first
@@ -152,37 +152,37 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
           writeTypeInfo(s, args.at(i)->type(), typeOptions);
           s << "\"";
         }
-        s << "};" << endl;
-        s << "      static const PythonQtMethodInfo* methodInfo = PythonQtMethodInfo::getCachedMethodInfoFromArgumentList(" << QString::number(args.size() + 1) << ", argumentList);" << endl;
+        s << "};" << Qt::endl;
+        s << "      static const PythonQtMethodInfo* methodInfo = PythonQtMethodInfo::getCachedMethodInfoFromArgumentList(" << QString::number(args.size() + 1) << ", argumentList);" << Qt::endl;
 
         if (hasReturnValue) {
           s << "      ";
           writeTypeInfo(s, fun->type(), typeOptions);
-          s << " returnValue{};" << endl;
+          s << " returnValue{};" << Qt::endl;
         }
         s << "      void* args[" << QString::number(args.size() + 1) << "] = {nullptr";
         for (int i = 0; i < args.size(); ++i) {
           s << ", (void*)&" << args.at(i)->indexedName();
         }
-        s << "};" << endl;
+        s << "};" << Qt::endl;
 
-        s << "      PyObject* result = PythonQtSignalTarget::call(obj, methodInfo, args, true);" << endl;
+        s << "      PyObject* result = PythonQtSignalTarget::call(obj, methodInfo, args, true);" << Qt::endl;
         if (hasReturnValue) {
-          s << "      if (result) {" << endl;
-          s << "        args[0] = PythonQtConv::ConvertPythonToQt(methodInfo->parameters().at(0), result, false, nullptr, &returnValue);" << endl;
-          s << "        if (args[0]!=&returnValue) {" << endl;
-          s << "          if (args[0]==nullptr) {" << endl;
-          s << "            PythonQt::priv()->handleVirtualOverloadReturnError(\"" << fun->name() << "\", methodInfo, result);" << endl;
-          s << "          } else {" << endl;
+          s << "      if (result) {" << Qt::endl;
+          s << "        args[0] = PythonQtConv::ConvertPythonToQt(methodInfo->parameters().at(0), result, false, nullptr, &returnValue);" << Qt::endl;
+          s << "        if (args[0]!=&returnValue) {" << Qt::endl;
+          s << "          if (args[0]==nullptr) {" << Qt::endl;
+          s << "            PythonQt::priv()->handleVirtualOverloadReturnError(\"" << fun->name() << "\", methodInfo, result);" << Qt::endl;
+          s << "          } else {" << Qt::endl;
           s << "            returnValue = *((";
           writeTypeInfo(s, fun->type(), typeOptions);
-          s << "*)args[0]);" << endl;
-          s << "          }" << endl;
-          s << "        }" << endl;
-          s << "      }" << endl;
+          s << "*)args[0]);" << Qt::endl;
+          s << "          }" << Qt::endl;
+          s << "        }" << Qt::endl;
+          s << "      }" << Qt::endl;
         }
-        s << "      if (result) { Py_DECREF(result); }" << endl;
-        s << "      Py_DECREF(obj);" << endl;
+        s << "      if (result) { Py_DECREF(result); }" << Qt::endl;
+        s << "      Py_DECREF(obj);" << Qt::endl;
         // ugly hack, we don't support QGraphicsScene* nor QGraphicsItem* QVariants in PythonQt...
         if (fun->name() == "itemChange" && fun->type() && fun->type()->isVariant()) {
             s << "      if (change0 == QGraphicsItem::ItemParentChange || change0 == QGraphicsItem::ItemSceneChange) {\n";
@@ -190,16 +190,16 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
             s << "      } \n";
         }
         if (hasReturnValue) {
-          s << "      return returnValue;" << endl;
+          s << "      return returnValue;" << Qt::endl;
         }
         else {
-          s << "      return;" << endl;
+          s << "      return;" << Qt::endl;
         }
-        s << "    } else {" << endl;
-        s << "      PyErr_Clear();" << endl;
-        s << "    }" << endl;
-        s << "  }" << endl;
-        s << "}" << endl;
+        s << "    } else {" << Qt::endl;
+        s << "      PyErr_Clear();" << Qt::endl;
+        s << "    }" << Qt::endl;
+        s << "  }" << Qt::endl;
+        s << "}" << Qt::endl;
       }
       s << "  ";
       if (fun->isAbstract()) {
@@ -227,7 +227,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
         }
         s << ");";
       }
-      s << endl << "}" << endl;
+      s << Qt::endl << "}" << Qt::endl;
     }
   }
 
@@ -240,8 +240,8 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
       s << meta_class->qualifiedCppName() << "* ";
       s << "PythonQtWrapper_" << meta_class->name() << "::";
       writeFunctionSignature(s, ctor, 0, "new_", Option(AddOwnershipTemplates | ShowStatic));
-      s << endl;
-      s << "{ " << endl;
+      s << Qt::endl;
+      s << "{ " << Qt::endl;
       s << "return new " << (meta_class->generateShellClass()?shellClassName(meta_class):meta_class->qualifiedCppName()) << "(";
       AbstractMetaArgumentList args = ctor->arguments();
       for (int i = 0; i < args.size(); ++i) {
@@ -249,25 +249,25 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
           s << ", ";
         s << args.at(i)->argumentName();
       }
-      s << ");" << " }" << endl << endl;
+      s << ");" << " }" << Qt::endl << Qt::endl;
     }
   }
 
   if (generateShell && meta_class->isQObject()) {
-    s << "const QMetaObject* " << shellClassName(meta_class) << "::metaObject() const {" << endl;
-    s << "  if (QObject::d_ptr->metaObject) {" << endl;
-    s << "    return QObject::d_ptr->dynamicMetaObject();" << endl;
-    s << "  } else if (_wrapper) {" << endl;
-    s << "    return PythonQt::priv()->getDynamicMetaObject(_wrapper, &" << meta_class->qualifiedCppName() << "::staticMetaObject);" << endl;
-    s << "  } else {" << endl;
-    s << "    return &" << meta_class->qualifiedCppName() << "::staticMetaObject;" << endl;
-    s << "  }" << endl;
-    s << "}" << endl;
+    s << "const QMetaObject* " << shellClassName(meta_class) << "::metaObject() const {" << Qt::endl;
+    s << "  if (QObject::d_ptr->metaObject) {" << Qt::endl;
+    s << "    return QObject::d_ptr->dynamicMetaObject();" << Qt::endl;
+    s << "  } else if (_wrapper) {" << Qt::endl;
+    s << "    return PythonQt::priv()->getDynamicMetaObject(_wrapper, &" << meta_class->qualifiedCppName() << "::staticMetaObject);" << Qt::endl;
+    s << "  } else {" << Qt::endl;
+    s << "    return &" << meta_class->qualifiedCppName() << "::staticMetaObject;" << Qt::endl;
+    s << "  }" << Qt::endl;
+    s << "}" << Qt::endl;
 
-    s << "int " << shellClassName(meta_class) << "::qt_metacall(QMetaObject::Call call, int id, void** args) {" << endl;
-    s << "  int result = " << meta_class->qualifiedCppName() << "::qt_metacall(call, id, args);" << endl;
-    s << "  return result >= 0 ? PythonQt::priv()->handleMetaCall(this, _wrapper, call, id, args) : result;" << endl;
-    s << "}" << endl;
+    s << "int " << shellClassName(meta_class) << "::qt_metacall(QMetaObject::Call call, int id, void** args) {" << Qt::endl;
+    s << "  int result = " << meta_class->qualifiedCppName() << "::qt_metacall(call, id, args);" << Qt::endl;
+    s << "  return result >= 0 ? PythonQt::priv()->handleMetaCall(this, _wrapper, call, id, args) : result;" << Qt::endl;
+    s << "}" << Qt::endl;
 
   }
 
@@ -283,7 +283,7 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
     writeFunctionSignature(s, fun, meta_class, QString(),
       Option(AddOwnershipTemplates | ConvertReferenceToPtr | FirstArgIsWrappedObject | ShowStatic | UnderscoreSpaces | ProtectedEnumAsInts),
       "PythonQtWrapper_");
-    s << endl << "{" << endl;
+    s << Qt::endl << "{" << Qt::endl;
     s << "  ";
     if (ShellGenerator::isSpecialStreamingOperator(fun)) {
       s << fun->arguments().at(0)->argumentName();
@@ -351,29 +351,29 @@ void ShellImplGenerator::write(QTextStream &s, const AbstractMetaClass *meta_cla
       }
       s << ")";
     }
-    s << ";" << endl;
+    s << ";" << Qt::endl;
 
-    s << "}" << endl << endl;
+    s << "}" << Qt::endl << Qt::endl;
   }
 
   if (meta_class->hasDefaultToStringFunction()) {
-    s << "QString PythonQtWrapper_" << meta_class->name() << "::py_toString(" << meta_class->qualifiedCppName() << "* obj) { return obj->toString(); }" << endl; 
+    s << "QString PythonQtWrapper_" << meta_class->name() << "::py_toString(" << meta_class->qualifiedCppName() << "* obj) { return obj->toString(); }" << Qt::endl; 
   } else if (meta_class->hasToStringCapability()) {
     FunctionModelItem fun = meta_class->hasToStringCapability();
     int indirections = fun->arguments().at(1)->type().indirections();
     QString deref = QLatin1String(indirections == 0 ? "*" : "");
-    s << "QString PythonQtWrapper_" << meta_class->name() << "::py_toString(" << meta_class->qualifiedCppName() << "* obj) {" << endl; 
-    s << "  QString result;" << endl;
-    s << "  QDebug d(&result);" << endl;
-    s << "  d << " << deref  << "obj;" << endl;
-    s << "  return result;" << endl;
-    s << "}" << endl << endl;
+    s << "QString PythonQtWrapper_" << meta_class->name() << "::py_toString(" << meta_class->qualifiedCppName() << "* obj) {" << Qt::endl; 
+    s << "  QString result;" << Qt::endl;
+    s << "  QDebug d(&result);" << Qt::endl;
+    s << "  d << " << deref  << "obj;" << Qt::endl;
+    s << "  return result;" << Qt::endl;
+    s << "}" << Qt::endl << Qt::endl;
   }
 
   writeInjectedCode(s, meta_class);
 
   if (meta_class->qualifiedCppName().contains("Ssl")) {
-    s << "#endif"  << endl;
+    s << "#endif"  << Qt::endl;
   }
 
   setCurrentScope(nullptr);
@@ -384,7 +384,7 @@ void ShellImplGenerator::writeInjectedCode(QTextStream &s, const AbstractMetaCla
   CodeSnipList code_snips = meta_class->typeEntry()->codeSnips();
   for (const CodeSnip& cs : code_snips) {
     if (cs.language == TypeSystem::PyWrapperCode) {
-      s << cs.code() << endl;
+      s << cs.code() << Qt::endl;
     }
   }
 }

--- a/generator/typesystem.cpp
+++ b/generator/typesystem.cpp
@@ -1878,7 +1878,7 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
         const QString line = lines.takeFirst().trimmed();
         if (line.isEmpty()) {
             if (!lastEmpty)
-                s << endl;
+                s << Qt::endl;
             lastEmpty = true;
             continue;
         } else {
@@ -1891,23 +1891,23 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
             s << indentor;
             if (line.startsWith("*"))
                 s << " ";
-            s << line << endl;
+            s << line << Qt::endl;
             if (line.endsWith("*/"))
                 multilineComment = false;
         } else if (line.startsWith("}")) {
             return line;
         } else if (line.endsWith("}")) {
-            s << indentor << line << endl;
+            s << indentor << line << Qt::endl;
             return 0;
         } else if(line.endsWith("{")) {
-            s << indentor << line << endl;
+            s << indentor << line << Qt::endl;
             QString tmp;
             {
                 Indentation indent(indentor);
                 tmp = formattedCodeHelper(s, indentor, lines);
             }
             if (!tmp.isNull()) {
-                s << indentor << tmp << endl;
+                s << indentor << tmp << Qt::endl;
             }
             lastLine = tmp;
             continue;
@@ -1921,7 +1921,7 @@ QString formattedCodeHelper(QTextStream &s, Indentor &indentor, QStringList &lin
                 !lastLine.endsWith("}") &&
                 !line.startsWith("{"))
                 s << "    ";
-            s << line << endl;
+            s << line << Qt::endl;
         }
         lastLine = line;
     }
@@ -1935,7 +1935,7 @@ QTextStream &CodeSnip::formattedCode(QTextStream &s, Indentor &indentor) const
     while (!lst.isEmpty()) {
         QString tmp = formattedCodeHelper(s, indentor, lst);
         if (!tmp.isNull()) {
-            s << indentor << tmp << endl;
+            s << indentor << tmp << Qt::endl;
         }
     }
     s.flush();

--- a/generator/typesystem.h
+++ b/generator/typesystem.h
@@ -61,24 +61,14 @@
     };
 #endif
 
-/* Global endl (::endl) is used extensively in the generator .cpp files.  This
- * was supported by Qt until Qt6.  In Qt5.14 Qt::endl was added in anticipation
- * of the Qt6 change and the use of global endl could be avoided (it does not
- * seem to have been explicitly deprecated).  This gives backward compatibility
- * for global endl in Qt6 (not Qt5, where global endl was still available).
- *
- * Note that 'constexpr' is available in Qt6 because Qt6 requires C++17;
- * constexpr was introduced in C++11.  Likewise for decltype.  Qt::endl is a
- * function so ::endl is a pointer to the function and the implicit conversion
- * is used; this is to cause an compiler error in the future if the base type
- * of Qt::endl changes.
- *
- * When versions of Qt older than 5.14 are no longer supported this can be
- * removed however all the 'endl' references in the code will need to be
- * changed to Qt::endl.
+/* Qt < 5.14 only provided ::endl (global). Create a namespaced alias so code
+ * can uniformly use Qt::endl across Qt versions.
  */
-#if QT_VERSION >= QT_VERSION_CHECK(6,0,0)
-    static constexpr decltype (Qt::endl) *endl = Qt::endl;
+#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
+    namespace Qt {
+        using qt_endl_t = QTextStream& (*)(QTextStream&);
+        static constexpr qt_endl_t endl = ::endl;
+    }
 #endif
 /* END: Qt compatibility. */
 


### PR DESCRIPTION
This changes the usage of the deprecated global `endl` with `Qt::endl` for compatibility with Qt 5.15.2 and above. The approach ensures that `Qt::endl` is used consistently across all versions of Qt by defining a namespaced alias for Qt versions below 5.14.0.

This follows up on the approach introduced in d11fc4fb ("Qt6: QTextStream compatibility (PR-120)", 2023-10-05) by explicitly using `Qt::endl` everywhere and by flipping the logic to have `Qt::endl` defined for Qt < 5.14.0

Warnings addressed:

```
/path/to/PythonQt/generator/typesystem.cpp: In function ‘QString formattedCodeHelper(QTextStream&, Indentor&, QStringList&)’:
/path/to/PythonQt/generator/typesystem.cpp:1900:38: warning: ‘QTextStream& QTextStreamFunctions::endl(QTextStream&)’ is deprecated: Use Qt::endl [-Wdeprecated-declarations]
 1900 |             s << indentor << line << endl;
      |                                      ^~~~
In file included from /path/to/Qt/5.15.2/gcc_64/include/QtCore/qdebug.h:49,
                 from /path/to/Qt/5.15.2/gcc_64/include/QtCore/QDebug:1,
                 from /path/to/PythonQt/generator/typesystem.h:49,
                 from /path/to/PythonQt/generator/typesystem.cpp:42:
/path/to/Qt/5.15.2/gcc_64/include/QtCore/qtextstream.h:293:75: note: declared here
  293 | Q_CORE_EXPORT QT_DEPRECATED_VERSION_X(5, 15, "Use Qt::endl") QTextStream &endl(QTextStream &s);
      |                                                                           ^~~~
```