### PR TITLE
Use Qt 6.10.0 explicitly in CI, as 6.10.1 fails

### DIFF
--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu', 'windows']
-        qt-version: [ '5.12.*', '5.15.*', '6.10.*' ]
+        qt-version: [ '5.12.*', '5.15.*', '6.10.0' ]
         python-version: [ '3.12' ]
     runs-on: ${{ matrix.os }}-latest
     steps:


### PR DESCRIPTION
- probably a problem with aqtinstall, see https://github.com/miurahr/aqtinstall/issues/803

If this passes, we can use it as a temporary solution until the problem is fixed.