### PR TITLE
Adjustments for Qt 6.10

### DIFF
--- a/generator/typesystem_core.xml
+++ b/generator/typesystem_core.xml
@@ -75,6 +75,7 @@
 <rejection class="QMetaTypeIdQObject"/>
 <rejection class="QPalette::Data"/>
 
+<rejection class="QRangeModel" since-version="6.10"/> <!-- templated range-based class -->
 <rejection class="QScopedPointerObjectDeleteLater"/>
 <rejection class="QScopedValueRollback"/>
 <rejection class="QSequentialIterable"/>
@@ -973,6 +974,24 @@ public:
     <modify-function signature="operator=(QString)" remove="all"/>
     <modify-function signature="addResourceSearchPath(QString)" remove="all"/>
     <!--### Obsolete in 4.3-->
+
+    <!-- Qt 6.10 changed mkpath/mkdir signatures to use std::optional<QFile::Permissions>
+         Since we don't support std::optional, we need to provide wrapper methods -->
+    <inject-code class="pywrap-h" since-version="6.10">
+    // Workaround for std::optional parameters in Qt 6.10
+    bool mkpath(QDir* theWrappedObject, const QString&amp; dirPath) const {
+      return theWrappedObject->mkpath(dirPath);
+    }
+    bool mkdir(QDir* theWrappedObject, const QString&amp; dirName) const {
+      return theWrappedObject->mkdir(dirName);
+    }
+    bool mkpath(QDir* theWrappedObject, const QString&amp; dirPath, QFile::Permissions permissions) const {
+      return theWrappedObject->mkpath(dirPath, permissions);
+    }
+    bool mkdir(QDir* theWrappedObject, const QString&amp; dirName, QFile::Permissions permissions) const {
+      return theWrappedObject->mkdir(dirName, permissions);
+    }
+    </inject-code>
   </value-type>
 
   <value-type name="QPoint">

--- a/generator/typesystem_gui.xml
+++ b/generator/typesystem_gui.xml
@@ -974,6 +974,7 @@
   <value-type name="QFontVariableAxis" since-version="6.9"/>
   <value-type name="QPainterStateGuard" since-version="6.9"/>
   <enum-type name="QPainterStateGuard::InitialState" since-version="6.9"/>
+  <object-type name="QAccessibilityHints" since-version="6.10"/>
 
   <value-type name="QTextTableCell">
     <extra-includes>
@@ -2336,6 +2337,7 @@ PyObject* constScanLine(QImage* image, int line) {
   <object-type name="QDateTimeEdit">
   </object-type>
 
+  <enum-type name="QSortFilterProxyModel::Direction" since-version="6.10"/>
   <object-type name="QSortFilterProxyModel">
      <modify-function signature="parent()const" remove="all"/>
     <extra-includes>

--- a/generator/typesystem_xml.xml
+++ b/generator/typesystem_xml.xml
@@ -10,6 +10,7 @@
     <enum-type name="QXmlStreamReader::Error"/>
     <enum-type name="QXmlStreamReader::TokenType"/>
     <enum-type name="QXmlStreamReader::ReadElementTextBehaviour"/>
+    <enum-type name="QXmlStreamWriter::Error" since-version="6.10"/>
 
 
     <value-type name="QDomAttr">


### PR DESCRIPTION
This includes some adjustments for Qt 6.10 as I have worked to update the 3D Slicer application to use Qt 6.10. I specifically ran into the issue where QDir's mkpath signature changed with a new std::optional argument which when unhandled was resulting in the wrapping for this method being unavailable and causing a traceback in 3D Slicer where mkpath was being used from python.

Additional changes based on reviewing some items described at https://doc.qt.io/qt-6/whatsnew610.html.