### PR TITLE
Add cmake build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build (QMake, Legacy Platforms)
 
 on:
   push:
@@ -16,6 +16,7 @@ defaults:
 
 jobs:
   ubuntu:
+    name: "QMake | Ubuntu ${{ matrix.container_version }} | Qt5 (system)"
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +130,7 @@ jobs:
         if-no-files-found: error
 
   oldschool:
+    name: "QMake | RockyLinux ${{ matrix.container_os_version }} | Qt5 | ${{ matrix.configuration }}"
     strategy:
       fail-fast: false
       matrix:
@@ -202,6 +204,7 @@ jobs:
         if-no-files-found: error
 
   macOS:
+    name: "QMake | macOS | Qt ${{ matrix.qt-version }} | ${{ matrix.configuration }}"
     strategy:
       fail-fast: false
       matrix:
@@ -305,6 +308,7 @@ jobs:
         if-no-files-found: error
 
   windows:
+    name: "QMake | Windows | ${{ matrix.qt-arch }} | Qt ${{ matrix.qt-version }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,4 +1,4 @@
-name: Build (CMake)
+name: Build (CMake, Latest Qt)
 
 on:
   push:
@@ -16,6 +16,7 @@ defaults:
 
 jobs:
   build:
+    name: "CMake | ${{ matrix.os }} | Qt ${{ matrix.qt-version }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -1,0 +1,149 @@
+name: Build (CMake)
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu', 'windows']
+        # Qt 5.12.* is excluded: CMakeLists.txt requires Qt >= 5.15.0.
+        qt-version: [ '5.15.*', '6.10.*' ]
+        python-version: [ '3.12' ]
+    runs-on: ${{ matrix.os }}-latest
+    steps:
+
+    - name: Install MSVC
+      if: ${{ matrix.os == 'windows' }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: amd64
+
+    - name: Install Qt ${{ matrix.qt-version }}
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: ${{ matrix.qt-version }}
+        modules: ${{ startsWith(matrix.qt-version, '6') && 'qt5compat qtscxml qtpositioning qtwebchannel qtmultimedia qtwebengine' || '' }}
+        arch: ${{ (matrix.os == 'ubuntu' && (startsWith(matrix.qt-version, '5') && 'gcc_64' || 'linux_gcc_64')) || startsWith(matrix.qt-version, '6') && 'win64_msvc2022_64' || 'win64_msvc2019_64' }}
+
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: '${{ matrix.python-version }}'
+
+    - name: Checkout PythonQt
+      uses: actions/checkout@v6
+
+    - name: Ccache
+      if: ${{ matrix.os == 'ubuntu' }}
+      uses: hendrikmuhs/ccache-action@v1.2.20
+      with:
+        key: ${{ runner.os }}-cmake-${{ matrix.qt-version }}
+        evict-old-files: 'job'
+
+    - name: Set environment
+      id: setenv
+      run: |
+        QT_VERSION_MAJOR=$(cut -f 1 -d . <<< "${{ matrix.qt-version }}")
+        echo "QT_VERSION_MAJOR=$QT_VERSION_MAJOR" >> $GITHUB_ENV
+        QT_VERSION_SHORT=$(cut -f 1,2 -d . <<< "${{ matrix.qt-version }}")
+        echo "QT_VERSION_SHORT=$QT_VERSION_SHORT" >> $GITHUB_OUTPUT
+        PYTHON_VERSION_FULL=$(python --version 2>&1 | cut -f 2 -d ' ')
+        PYTHON_VERSION_SHORT=$(cut -f 1,2 -d . <<< $PYTHON_VERSION_FULL)
+        echo "PYTHON_VERSION_SHORT=$PYTHON_VERSION_SHORT" >> $GITHUB_OUTPUT
+        echo "$pythonLocation/bin" >> $GITHUB_PATH
+
+    - name: Build generator (Ubuntu)
+      if: ${{ matrix.os == 'ubuntu' }}
+      run: |
+        cmake -G Ninja -S generator -B generator/build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
+          -DPythonQtGenerator_QT_VERSION=$QT_VERSION_MAJOR
+        cmake --build generator/build
+
+    - name: Build generator (Windows)
+      if: ${{ matrix.os == 'windows' }}
+      shell: cmd
+      run: |
+        set QT_CMAKE_DIR=%QT_ROOT_DIR%\lib\cmake\Qt%QT_VERSION_MAJOR%
+        cmake -G "Visual Studio 17 2022" -S generator -B generator\build ^
+          "-DCMAKE_PREFIX_PATH=%QT_ROOT_DIR%;%QT_ROOT_DIR%\lib\cmake" ^
+          "-DQt%QT_VERSION_MAJOR%_DIR=%QT_CMAKE_DIR%" ^
+          -DPythonQtGenerator_QT_VERSION=%QT_VERSION_MAJOR% || exit /b 1
+        cmake --build generator\build --config Release || exit /b 1
+
+    - name: Generate Wrappers (Ubuntu)
+      if: ${{ matrix.os == 'ubuntu' }}
+      run: |
+        QTDIR="$QT_ROOT_DIR" \
+        UBSAN_OPTIONS="halt_on_error=1" \
+        ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        ./generator/build/PythonQtGenerator \
+          --output-directory=.
+
+    - name: Generate Wrappers (Windows)
+      if: ${{ matrix.os == 'windows' }}
+      shell: cmd
+      run: |
+        set QTDIR=%QT_ROOT_DIR%
+        generator\build\Release\PythonQtGenerator.exe --output-directory=. || exit /b 1
+
+    - name: Upload Wrappers
+      uses: actions/upload-artifact@v7
+      with:
+        name: cmake_wrappers_${{ matrix.os }}_${{ steps.setenv.outputs.QT_VERSION_SHORT }}
+        path: generated_cpp
+        if-no-files-found: error
+
+    - name: Build and test PythonQt (Ubuntu)
+      if: ${{ matrix.os == 'ubuntu' }}
+      run: |
+        cmake -G Ninja -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_PREFIX_PATH="$QT_ROOT_DIR" \
+          -DPythonQt_QT_VERSION=$QT_VERSION_MAJOR \
+          "-DPythonQt_GENERATED_PATH=$(pwd)/generated_cpp" \
+          -DPythonQt_Wrap_QtCore=ON \
+          -DBUILD_TESTING=ON \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          "-DCMAKE_CXX_FLAGS=-fsanitize=address,undefined -fno-sanitize-recover=undefined" \
+          "-DCMAKE_EXE_LINKER_FLAGS=-fsanitize=address,undefined" \
+          "-DCMAKE_SHARED_LINKER_FLAGS=-fsanitize=address,undefined"
+        cmake --build build --parallel $(nproc)
+        PYTHONDEVMODE=1 PYTHONASYNCIODEBUG=1 PYTHONWARNINGS=error PYTHONMALLOC=malloc_debug \
+        UBSAN_OPTIONS="halt_on_error=1" ASAN_OPTIONS="detect_leaks=0:detect_stack_use_after_return=1:fast_unwind_on_malloc=0" \
+        QT_QPA_PLATFORM=offscreen \
+        ctest --test-dir build --output-on-failure
+
+    - name: Build and test PythonQt (Windows)
+      if: ${{ matrix.os == 'windows' }}
+      shell: cmd
+      run: |
+        set QT_CMAKE_DIR=%QT_ROOT_DIR%\lib\cmake\Qt%QT_VERSION_MAJOR%
+        cmake -G "Visual Studio 17 2022" -S . -B build ^
+          "-DCMAKE_PREFIX_PATH=%QT_ROOT_DIR%;%QT_ROOT_DIR%\lib\cmake" ^
+          "-DQt%QT_VERSION_MAJOR%_DIR=%QT_CMAKE_DIR%" ^
+          -DPythonQt_QT_VERSION=%QT_VERSION_MAJOR% ^
+          "-DPythonQt_GENERATED_PATH=%CD%\generated_cpp" ^
+          -DPythonQt_Wrap_QtCore=ON ^
+          -DBUILD_TESTING=ON || exit /b 1
+        cmake --build build --config Release || exit /b 1
+        set PYTHONDEVMODE=1
+        set PYTHONASYNCIODEBUG=1
+        set PYTHONWARNINGS=error
+        set QT_QPA_PLATFORM=offscreen
+        ctest --test-dir build --output-on-failure -C Release || exit /b 1

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -122,7 +122,6 @@ jobs:
         python --version
         qmake CONFIG+=release CONFIG-=debug_and_release CONFIG-=debug_and_release_target ^
            CONFIG+=exclude_generator ^
-           "PYTHONQTALL_CONFIG=${{ matrix.pythonqtall-config }}" ^
            "PYTHON_PATH=%pythonLocation%" ^
            "PYTHON_VERSION=${{ steps.setenv.outputs.PYTHON_VERSION_SHORT }}" ^
            PythonQt.pro

--- a/.github/workflows/build_latest.yml
+++ b/.github/workflows/build_latest.yml
@@ -1,4 +1,4 @@
-name: Check generated_cpp
+name: Build (QMake, Latest Qt)
 
 on:
   push:
@@ -16,6 +16,7 @@ defaults:
 
 jobs:
   build:
+    name: "QMake | ${{ matrix.os }} | Qt ${{ matrix.qt-version }}"
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,275 @@
+
+cmake_minimum_required(VERSION 3.20.6)
+
+project(PythonQt)
+
+#----------------------------------------------------------------------------
+# Qt version
+
+set(_default_qt_major_version 5)
+if(DEFINED Qt6_DIR)
+  set(_default_qt_major_version 6)
+endif()
+
+# Set PythonQt_QT_VERSION
+set(PythonQt_QT_VERSION ${_default_qt_major_version} CACHE STRING "Qt major version (5 or 6)")
+set_property(CACHE PythonQt_QT_VERSION PROPERTY STRINGS "5" "6")
+if(NOT "${PythonQt_QT_VERSION}" MATCHES "^(5|6)$")
+  message(FATAL_ERROR "error: PythonQt_QT_VERSION must be 5 or 6.")
+endif()
+
+# Requirements
+set(minimum_required_qt5_version "5.15.0")
+set(minimum_required_qt6_version "6.4.0")
+set(minimum_required_qt_version ${minimum_required_qt${PythonQt_QT_VERSION}_version})
+
+find_package(Qt${PythonQt_QT_VERSION} ${minimum_required_qt_version} QUIET)
+
+#----------------------------------------------------------------------------
+# Qt components
+set(qtlibs
+  Core
+  Widgets
+  Network
+  OpenGL
+  Qml
+  Quick
+  Sql
+  Svg
+  Multimedia
+  WebEngineWidgets
+  UiTools
+  Xml
+  )
+# XmlPatterns and WebKitWidgets are removed from Qt 6
+if(PythonQt_QT_VERSION VERSION_EQUAL "5")
+  list(APPEND qtlibs
+    XmlPatterns
+    WebKitWidgets
+  )
+endif()
+
+#-----------------------------------------------------------------------------
+# Python libraries
+
+find_package(Python3 COMPONENTS Development REQUIRED)
+
+#-----------------------------------------------------------------------------
+# Build options
+
+option(PythonQt_SUPPORT_NAME_PROPERTY "Enable PythonQt name-property support" ON)
+option(PythonQt_USE_RELEASE_PYTHON_FALLBACK "Fallback to Release python when Debug missing" ON)
+option(PythonQt_DEBUG "Enable PythonQt debug output" OFF)
+option(PythonQt_BUILD_QTALL "Build PythonQt_QtAll bindings as a separate library" ON)
+
+if(NOT DEFINED PythonQt_INSTALL_RUNTIME_DIR)
+  set(PythonQt_INSTALL_RUNTIME_DIR bin)
+endif()
+
+if(NOT DEFINED PythonQt_INSTALL_LIBRARY_DIR)
+  set(PythonQt_INSTALL_LIBRARY_DIR lib${LIB_SUFFIX})
+endif()
+
+if(NOT DEFINED PythonQt_INSTALL_ARCHIVE_DIR)
+  set(PythonQt_INSTALL_ARCHIVE_DIR lib${LIB_SUFFIX})
+endif()
+
+if(NOT DEFINED PythonQt_INSTALL_INCLUDE_DIR)
+  set(PythonQt_INSTALL_INCLUDE_DIR include/PythonQt)
+endif()
+
+#-----------------------------------------------------------------------------
+# Set qtlib_to_wraplib_* variables
+
+set(qtlib_to_wraplib_Widgets gui)
+set(qtlib_to_wraplib_WebKitWidgets webkit)
+
+set(qt_wrapped_lib_depends_gui Multimedia PrintSupport)
+if(PythonQt_QT_VERSION VERSION_EQUAL "6")
+  list(APPEND qt_wrapped_lib_depends_gui Widgets OpenGL)
+endif()
+set(qt_wrapped_lib_depends_multimedia MultimediaWidgets)
+set(qt_wrapped_lib_depends_quick QuickWidgets)
+set(qt_wrapped_lib_depends_svg )
+if(PythonQt_QT_VERSION VERSION_EQUAL "6")
+  list(APPEND qt_wrapped_lib_depends_svg SvgWidgets)
+endif()
+set(qt_wrapped_lib_depends_webenginewidgets )
+set(qt_wrapped_lib_depends_webkit )
+
+foreach(qtlib ${qtlibs})
+  string(TOLOWER ${qtlib} qtlib_lowercase)
+  if(DEFINED qtlib_to_wraplib_${qtlib})
+    set(qtlib_lowercase ${qtlib_to_wraplib_${qtlib}})
+  endif()
+  set(qtlib_to_wraplib_${qtlib} ${qtlib_lowercase})
+endforeach()
+
+#-----------------------------------------------------------------------------
+# Define PythonQt_Wrap_Qt* options
+option(PythonQt_Wrap_QtAll "Make all Qt components available in python" OFF)
+foreach(qtlib ${qtlibs})
+  OPTION(PythonQt_Wrap_Qt${qtlib_to_wraplib_${qtlib}} "Make all of Qt${qtlib} available in python" OFF)
+endforeach()
+
+#-----------------------------------------------------------------------------
+# Force option if it applies
+if(PythonQt_Wrap_QtAll)
+  foreach(qtlib ${qtlibs})
+    # XXX xmlpatterns wrapper does *NOT* build at all :(
+    if(${qtlib} STREQUAL "XmlPatterns")
+      continue()
+    endif()
+    set(qt_wrapped_lib ${qtlib_to_wraplib_${qtlib}})
+    if(NOT ${PythonQt_Wrap_Qt${qt_wrapped_lib}})
+      set(PythonQt_Wrap_Qt${qt_wrapped_lib} ON CACHE BOOL "Make all of Qt${qt_wrapped_lib} available in python" FORCE)
+      message(STATUS "Enabling [PythonQt_Wrap_Qt${qt_wrapped_lib}] because of [PythonQt_Wrap_QtAll] evaluates to True")
+    endif()
+  endforeach()
+endif()
+
+#-----------------------------------------------------------------------------
+# Setup Qt
+
+# Required components
+set(qt_required_components Core Widgets)
+foreach(qtlib ${qtlibs})
+  set(qt_wrapped_lib ${qtlib_to_wraplib_${qtlib}})
+  if(${PythonQt_Wrap_Qt${qt_wrapped_lib}})
+    list(APPEND qt_required_components ${qtlib} ${qt_wrapped_lib_depends_${qt_wrapped_lib}})
+  endif()
+endforeach()
+if(BUILD_TESTING)
+  list(APPEND qt_required_components Test)
+endif()
+if("${Qt${PythonQt_QT_VERSION}_VERSION}" VERSION_GREATER_EQUAL "6.10.0")
+  list(APPEND qt_required_components CorePrivate)
+endif()
+list(REMOVE_DUPLICATES qt_required_components)
+
+message(STATUS "${PROJECT_NAME}: Required Qt components [${qt_required_components}]")
+find_package(Qt${PythonQt_QT_VERSION} ${minimum_required_qt_version} COMPONENTS ${qt_required_components} REQUIRED)
+
+set(QT_VERSION_MAJOR ${Qt${PythonQt_QT_VERSION}_VERSION_MAJOR})
+set(QT_VERSION_MINOR ${Qt${PythonQt_QT_VERSION}_VERSION_MINOR})
+
+set(QT_LIBRARIES )
+foreach(qt_component ${qt_required_components})
+  list(APPEND QT_LIBRARIES Qt${PythonQt_QT_VERSION}::${qt_component})
+endforeach()
+
+if(UNIX)
+  find_package(OpenGL)
+  if(OPENGL_FOUND)
+    list(APPEND QT_LIBRARIES ${OPENGL_LIBRARIES})
+  endif()
+endif()
+
+#-----------------------------------------------------------------------------
+# Pre-generated wrappers default to Qt 5.15 set (generated_cpp_515). Users may override.
+if(PythonQt_QT_VERSION VERSION_EQUAL "5")
+  set(generated_cpp_suffix "_515")
+  set(_default_generated_path "${CMAKE_CURRENT_SOURCE_DIR}/generated_cpp${generated_cpp_suffix}")
+else()
+  set(_default_generated_path "PythonQt_GENERATED_PATH-NOTFOUND")
+endif()
+
+set(PythonQt_GENERATED_PATH "${_default_generated_path}"
+  CACHE PATH "Directory containing pre-generated PythonQt Qt wrappers for Qt ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR} (e.g., generated_cpp_515)")
+
+if(NOT IS_DIRECTORY "${PythonQt_GENERATED_PATH}")
+  message(FATAL_ERROR
+    "PythonQt: missing generated wrapper sources for Qt ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.\n"
+    "Expected: ${PythonQt_GENERATED_PATH}\n"
+    "Hint: pass -DPythonQt_GENERATED_PATH:PATH=/path/to/generated_cpp")
+endif()
+
+#-----------------------------------------------------------------------------
+# Build targets
+add_subdirectory(src)
+if(PythonQt_BUILD_QTALL)
+  add_subdirectory(extensions/PythonQt_QtAll)
+endif()
+
+#-----------------------------------------------------------------------------
+# Testing
+
+option(BUILD_TESTING "Build the testing tree." OFF)
+include(CTest)
+
+if(BUILD_TESTING)
+  create_test_sourcelist(test_sources PythonQtCppTests.cpp
+    tests/PythonQtTestMain.cpp
+    )
+
+  set_property(SOURCE tests/PythonQtTestMain.cpp PROPERTY COMPILE_DEFINITIONS "main=tests_PythonQtTestMain")
+
+  list(APPEND test_sources
+    tests/PythonQtTests.cpp
+    tests/PythonQtTests.h
+    )
+
+  if(PythonQt_Wrap_QtCore AND PythonQt_BUILD_QTALL)
+    list(APPEND test_sources
+      tests/PythonQtTestCleanup.cpp
+      tests/PythonQtTestCleanup.h
+      )
+
+    set_property(SOURCE tests/PythonQtTestMain.cpp APPEND PROPERTY COMPILE_DEFINITIONS "PythonQt_Wrap_QtCore")
+  endif()
+
+  add_executable(PythonQtCppTests ${test_sources})
+
+  target_include_directories(PythonQtCppTests
+    PRIVATE
+      $<$<BOOL:${PythonQt_Wrap_QtCore}>:${PythonQt_GENERATED_PATH}>
+      $<$<AND:$<BOOL:${PythonQt_Wrap_QtCore}>,$<BOOL:${PythonQt_BUILD_QTALL}>>:${CMAKE_CURRENT_SOURCE_DIR}/extensions/PythonQt_QtAll>
+    )
+
+  target_link_libraries(PythonQtCppTests PythonQt)
+  if(PythonQt_Wrap_QtCore AND PythonQt_BUILD_QTALL)
+    target_link_libraries(PythonQtCppTests PythonQt_QtAll)
+  endif()
+
+  set_target_properties(PythonQtCppTests
+    PROPERTIES
+      AUTOMOC TRUE
+    )
+
+  target_compile_definitions(PythonQtCppTests
+    PRIVATE
+      $<$<BOOL:${PythonQt_SUPPORT_NAME_PROPERTY}>:PYTHONQT_SUPPORT_NAME_PROPERTY>
+    )
+
+  if(WIN32)
+    # Python3::Python may resolve to the import library directory (e.g. .../libs),
+    # while pythonXY.dll typically lives one level above. Add both.
+    get_filename_component(_python3_lib_dir "${Python3_LIBRARY}" DIRECTORY)
+    get_filename_component(_python3_root_dir "${_python3_lib_dir}" DIRECTORY)
+
+    set(_pythonqt_test_path_entries
+      "$<TARGET_FILE_DIR:PythonQtCppTests>"
+      "$<TARGET_FILE_DIR:PythonQt>"
+      "$<TARGET_FILE_DIR:Qt${PythonQt_QT_VERSION}::Core>"
+      "$<TARGET_FILE_DIR:Python3::Python>"
+      "${_python3_lib_dir}"
+      "${_python3_root_dir}"
+      )
+    if(PythonQt_BUILD_QTALL)
+      list(APPEND _pythonqt_test_path_entries "$<TARGET_FILE_DIR:PythonQt_QtAll>")
+    endif()
+    list(JOIN _pythonqt_test_path_entries ";" _pythonqt_test_path_prefix)
+    set(_pythonqt_test_env "PATH=${_pythonqt_test_path_prefix};$ENV{PATH}")
+
+    add_test(
+      NAME tests_PythonQtTestMain
+      COMMAND ${CMAKE_COMMAND} -E env "${_pythonqt_test_env}" $<TARGET_FILE:PythonQtCppTests> tests/PythonQtTestMain
+      )
+  else()
+    add_test(
+      NAME tests_PythonQtTestMain
+      COMMAND $<TARGET_FILE:PythonQtCppTests> tests/PythonQtTestMain
+      )
+  endif()
+endif()
+

--- a/extensions/PythonQt_QtAll/CMakeLists.txt
+++ b/extensions/PythonQt_QtAll/CMakeLists.txt
@@ -1,0 +1,89 @@
+#-----------------------------------------------------------------------------
+# Build PythonQt_QtAll bindings as a dedicated shared library.
+
+set(pythonqt_qtall_sources
+  PythonQt_QtAll.cpp
+)
+
+set(pythonqt_qtall_headers
+  PythonQt_QtAll.h
+)
+
+set(pythonqt_qtall_moc_headers)
+set(pythonqt_qtall_components)
+set(pythonqt_qtall_defines)
+
+foreach(qtlib ${qtlibs})
+  set(qt_wrapped_lib ${qtlib_to_wraplib_${qtlib}})
+
+  if(PythonQt_Wrap_Qt${qt_wrapped_lib})
+    string(TOUPPER ${qt_wrapped_lib} qt_wrapped_lib_uppercase)
+    list(APPEND pythonqt_qtall_defines PYTHONQT_WITH_${qt_wrapped_lib_uppercase})
+
+    list(APPEND pythonqt_qtall_components ${qtlib} ${qt_wrapped_lib_depends_${qt_wrapped_lib}})
+
+    set(file_prefix com_trolltech_qt_${qt_wrapped_lib}/com_trolltech_qt_${qt_wrapped_lib})
+
+    # Collect generated wrapper files without relying on a fixed index range.
+    file(GLOB generated_cpp_files "${PythonQt_GENERATED_PATH}/${file_prefix}[0-9]*.cpp")
+    list(SORT generated_cpp_files)
+    list(APPEND pythonqt_qtall_sources ${generated_cpp_files})
+
+    file(GLOB generated_h_files "${PythonQt_GENERATED_PATH}/${file_prefix}[0-9]*.h")
+    list(SORT generated_h_files)
+    list(APPEND pythonqt_qtall_moc_headers ${generated_h_files})
+
+    set(init_cpp_file "${PythonQt_GENERATED_PATH}/${file_prefix}_init.cpp")
+    if(EXISTS "${init_cpp_file}")
+      list(APPEND pythonqt_qtall_sources ${init_cpp_file})
+    endif()
+  endif()
+endforeach()
+
+list(REMOVE_DUPLICATES pythonqt_qtall_components)
+
+qt_wrap_cpp(pythonqt_qtall_sources ${pythonqt_qtall_moc_headers})
+
+add_library(PythonQt_QtAll SHARED ${pythonqt_qtall_sources})
+set_target_properties(PythonQt_QtAll PROPERTIES DEFINE_SYMBOL PYTHONQT_QTALL_EXPORTS)
+
+set_target_properties(PythonQt_QtAll
+  PROPERTIES
+    AUTOMOC TRUE
+)
+
+# Disable AUTOMOC for specified moc sources to avoid QMetaTypeId specialization conflicts.
+foreach(moc_source IN LISTS pythonqt_qtall_moc_headers)
+  set_property(SOURCE ${moc_source} PROPERTY SKIP_AUTOMOC ON)
+endforeach()
+
+target_compile_options(PythonQt_QtAll PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+)
+
+target_compile_definitions(PythonQt_QtAll
+  PRIVATE
+    ${pythonqt_qtall_defines}
+)
+
+target_include_directories(PythonQt_QtAll
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<INSTALL_INTERFACE:${PythonQt_INSTALL_INCLUDE_DIR}>
+)
+
+target_link_libraries(PythonQt_QtAll
+  PUBLIC
+    PythonQt
+)
+
+foreach(qt_component IN LISTS pythonqt_qtall_components)
+  target_link_libraries(PythonQt_QtAll PUBLIC Qt${PythonQt_QT_VERSION}::${qt_component})
+endforeach()
+
+install(TARGETS PythonQt_QtAll
+  RUNTIME DESTINATION ${PythonQt_INSTALL_RUNTIME_DIR}
+  LIBRARY DESTINATION ${PythonQt_INSTALL_LIBRARY_DIR}
+  ARCHIVE DESTINATION ${PythonQt_INSTALL_ARCHIVE_DIR}
+)
+install(FILES ${pythonqt_qtall_headers} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR})

--- a/extensions/PythonQt_QtAll/PythonQt_QtAll.cpp
+++ b/extensions/PythonQt_QtAll/PythonQt_QtAll.cpp
@@ -71,6 +71,10 @@ void PythonQt_init_QtQuick(PyObject*);
 void PythonQt_init_QtUiTools(PyObject*);
 #endif
 
+#ifdef PYTHONQT_WITH_WEBENGINEWIDGETS
+void PythonQt_init_QtWebEngineWidgets(PyObject*);
+#endif
+
 #ifdef PYTHONQT_WITH_WEBKIT
 void PythonQt_init_QtWebKit(PyObject*);
 #endif
@@ -116,6 +120,9 @@ PYTHONQT_QTALL_EXPORT void init()
 #endif
 #ifdef PYTHONQT_WITH_UITOOLS
   PythonQt_init_QtUiTools(0);
+#endif
+#ifdef PYTHONQT_WITH_WEBENGINEWIDGETS
+  PythonQt_init_QtWebEngineWidgets(0);
 #endif
 }
 }

--- a/generator/CMakeLists.txt
+++ b/generator/CMakeLists.txt
@@ -1,37 +1,39 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.20.6)
 
-#-----------------------------------------------------------------------------
-project(PythonQtGenerator)
-#-----------------------------------------------------------------------------
+project(PythonQtGenerator LANGUAGES CXX)
 
-include(CTestUseLaunchers OPTIONAL)
-
-#-----------------------------------------------------------------------------
+#----------------------------------------------------------------------------
 # Setup Qt
 
-set(minimum_required_qt_version "4.6.2")
-
-find_package(Qt4)
-
-if(QT4_FOUND)
-
-  set(found_qt_version ${QT_VERSION_MAJOR}.${QT_VERSION_MINOR}.${QT_VERSION_PATCH})
-
-  if(${found_qt_version} VERSION_LESS ${minimum_required_qt_version})
-      message(FATAL_ERROR "error: PythonQt requires Qt >= ${minimum_required_qt_version} -- you cannot use Qt ${found_qt_version}.")
-  endif()
-
-  set(QT_USE_QTXML ON)
-
-  include(${QT_USE_FILE})
-else()
-  message(FATAL_ERROR "error: Qt4 was not found on your system. You probably need to set the QT_QMAKE_EXECUTABLE variable")
+set(_default_qt_major_version 5)
+if(DEFINED Qt6_DIR)
+  set(_default_qt_major_version 6)
 endif()
+
+# Set PythonQtGenerator_QT_VERSION
+set(PythonQtGenerator_QT_VERSION ${_default_qt_major_version} CACHE STRING "Qt major version (5 or 6)")
+set_property(CACHE PythonQtGenerator_QT_VERSION PROPERTY STRINGS "5" "6")
+if(NOT "${PythonQtGenerator_QT_VERSION}" MATCHES "^(5|6)$")
+  message(FATAL_ERROR "error: PythonQtGenerator_QT_VERSION must be 5 or 6.")
+endif()
+
+set(minimum_required_qt5_version "5.15.0")
+set(minimum_required_qt6_version "6.4.0")
+set(minimum_required_qt_version ${minimum_required_qt${PythonQtGenerator_QT_VERSION}_version})
+
+set(qt_required_components Core Xml)
+
+message(STATUS "${PROJECT_NAME}: Required Qt${PythonQtGenerator_QT_VERSION} components [${qt_required_components}]")
+
+# Requirements
+find_package(Qt${PythonQtGenerator_QT_VERSION} ${minimum_required_qt_version}
+  COMPONENTS ${qt_required_components} REQUIRED)
 
 #-----------------------------------------------------------------------------
 # Sources
 
 set(sources
+  # Based of parser/rxx.pro
   parser/ast.cpp
   parser/binder.cpp
   parser/class_compiler.cpp
@@ -51,107 +53,61 @@ set(sources
   parser/type_compiler.cpp
   parser/visitor.cpp
 
+  # Based of simplecpp/simplecpp.pri
+  simplecpp/simplecpp.cpp
+
+  # Based of generator.pri
   abstractmetabuilder.cpp
   abstractmetalang.cpp
   asttoxml.cpp
   customtypes.cpp
   fileout.cpp
   generator.cpp
+  generator.qrc
   generatorset.cpp
-  generatorsetqtscript.cpp
   main.cpp
   metajava.cpp
-  metaqtscriptbuilder.cpp
-  metaqtscript.cpp
   prigenerator.cpp
   reporthandler.cpp
+  typeparser.cpp
+  typesystem.cpp
+
+  # Based of generator.pro
+  generatorsetqtscript.cpp
+  metaqtscriptbuilder.cpp
+  metaqtscript.cpp
   setupgenerator.cpp
   shellgenerator.cpp
   shellheadergenerator.cpp
   shellimplgenerator.cpp
-  typeparser.cpp
-  typesystem.cpp
   )
 
-#-----------------------------------------------------------------------------
-# List headers.  This list is used for the install command.
+add_executable(${PROJECT_NAME} ${sources})
 
-set(headers
+set_target_properties(${PROJECT_NAME}
+  PROPERTIES
+    AUTOMOC TRUE
+    AUTORCC TRUE
   )
 
-#-----------------------------------------------------------------------------
-# Headers that should run through moc
-
-set(moc_sources
-  fileout.h
-  generator.h
-  generatorset.h
-  generatorsetqtscript.h
-  prigenerator.h
-  setupgenerator.h
-  shellgenerator.h
-  shellheadergenerator.h
-  shellimplgenerator.h
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/parser>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/simplecpp>
   )
 
-#-----------------------------------------------------------------------------
-# UI files
-
-set(ui_sources )
-
-#-----------------------------------------------------------------------------
-# Resources
-
-set(qrc_sources
-  generator.qrc
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    Qt${PythonQtGenerator_QT_VERSION}::Core
+    Qt${PythonQtGenerator_QT_VERSION}::Xml
   )
 
-#-----------------------------------------------------------------------------
-# Do wrapping
-qt4_wrap_cpp(gen_moc_sources ${moc_sources})
-qt4_wrap_ui(gen_ui_sources ${ui_sources})
-qt4_add_resources(gen_qrc_sources ${qrc_sources})
-
-#-----------------------------------------------------------------------------
-# Copy file expected by the generator and specify install rules
-
-file(GLOB files_to_copy RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "build_*.txt" "typesystem_*.xml")
-list(APPEND files_to_copy qtscript_masterinclude.h parser/rpp/pp-qt-configuration)
-foreach(file ${files_to_copy})
-  configure_file(
-    ${file}
-    ${CMAKE_CURRENT_BINARY_DIR}/${file}
-    COPYONLY
-    )
-  get_filename_component(destination_dir ${file} PATH)
-  install(FILES ${file} DESTINATION bin/${destination_dir})
-endforeach()
-
-#-----------------------------------------------------------------------------
-# Build the library
-
-SOURCE_GROUP("Resources" FILES
-  ${qrc_sources}
-  ${ui_sources}
-  ${files_to_copy}
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+      RXX_ALLOCATOR_INIT_0 # Based of parser/rxx.pro
+      QT_NO_CAST_TO_ASCII # Based of generator.pro
   )
-
-include_directories(
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/parser
-  ${CMAKE_CURRENT_SOURCE_DIR}/parser/rpp
-  )
-
-add_definitions(-DRXX_ALLOCATOR_INIT_0)
-
-add_executable(${PROJECT_NAME}
-  ${sources}
-  ${gen_moc_sources}
-  ${gen_ui_sources}
-  ${gen_qrc_sources}
-)
-
-target_link_libraries(${PROJECT_NAME} ${QT_LIBRARIES})
 
 #-----------------------------------------------------------------------------
 # Install library (on windows, put the dll in 'bin' and the archive in 'lib')

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,128 @@
+#-----------------------------------------------------------------------------
+# Sources
+
+set(pythonqt_sources
+  PythonQtBoolResult.cpp
+  PythonQtClassInfo.cpp
+  PythonQtClassWrapper.cpp
+  PythonQtConversion.cpp
+  PythonQt.cpp
+  PythonQtImporter.cpp
+  PythonQtInstanceWrapper.cpp
+  PythonQtMethodInfo.cpp
+  PythonQtMisc.cpp
+  PythonQtObjectPtr.cpp
+  PythonQtProperty.cpp
+  PythonQtQFileImporter.cpp
+  PythonQtSignalReceiver.cpp
+  PythonQtSlot.cpp
+  PythonQtSlotDecorator.cpp
+  PythonQtSignal.cpp
+  PythonQtStdDecorators.cpp
+  PythonQtStdIn.cpp
+  PythonQtStdOut.cpp
+  PythonQtThreadSupport.cpp
+  gui/PythonQtScriptingConsole.cpp
+
+  ${PythonQt_GENERATED_PATH}/com_trolltech_qt_core_builtin/com_trolltech_qt_core_builtin0.cpp
+  ${PythonQt_GENERATED_PATH}/com_trolltech_qt_core_builtin/com_trolltech_qt_core_builtin_init.cpp
+  ${PythonQt_GENERATED_PATH}/com_trolltech_qt_gui_builtin/com_trolltech_qt_gui_builtin0.cpp
+  ${PythonQt_GENERATED_PATH}/com_trolltech_qt_gui_builtin/com_trolltech_qt_gui_builtin_init.cpp
+)
+
+#-----------------------------------------------------------------------------
+# List headers. This list is used for the install command.
+
+set(pythonqt_headers
+  PythonQtBoolResult.h
+  PythonQtClassInfo.h
+  PythonQtClassWrapper.h
+  PythonQtConversion.h
+  PythonQtCppWrapperFactory.h
+  PythonQtDoc.h
+  PythonQt.h
+  PythonQtImporter.h
+  PythonQtImportFileInterface.h
+  PythonQtInstanceWrapper.h
+  PythonQtMethodInfo.h
+  PythonQtMisc.h
+  PythonQtObjectPtr.h
+  PythonQtProperty.h
+  PythonQtQFileImporter.h
+  PythonQtSignalReceiver.h
+  PythonQtSlot.h
+  PythonQtSlotDecorator.h
+  PythonQtSignal.h
+  PythonQtStdDecorators.h
+  PythonQtStdIn.h
+  PythonQtStdOut.h
+  PythonQtSystem.h
+  PythonQtThreadSupport.h
+  PythonQtUtils.h
+  PythonQtVariants.h
+  PythonQtPythonInclude.h
+)
+
+#-----------------------------------------------------------------------------
+# Configure header
+
+# Map the CMake option `PythonQt_USE_RELEASE_PYTHON_FALLBACK` (camelCase)
+# to a plain variable used by the configured header. The public-facing
+# preprocessor symbol remains `PYTHONQT_USE_RELEASE_PYTHON_FALLBACK`.
+set(PYTHONQT_USE_RELEASE_PYTHON_FALLBACK ${PythonQt_USE_RELEASE_PYTHON_FALLBACK})
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/PythonQtConfigure.h.in
+  ${CMAKE_CURRENT_BINARY_DIR}/PythonQtConfigure.h
+)
+unset(PYTHONQT_USE_RELEASE_PYTHON_FALLBACK)
+
+list(APPEND pythonqt_headers
+  ${CMAKE_CURRENT_BINARY_DIR}/PythonQtConfigure.h
+)
+
+#-----------------------------------------------------------------------------
+# Build the library
+
+add_library(PythonQt SHARED ${pythonqt_sources})
+set_target_properties(PythonQt PROPERTIES DEFINE_SYMBOL PYTHONQT_EXPORTS)
+
+set_target_properties(PythonQt
+  PROPERTIES
+    AUTOMOC TRUE
+)
+
+target_compile_definitions(PythonQt
+  PRIVATE
+    $<$<BOOL:${PythonQt_DEBUG}>:PYTHONQT_DEBUG>
+    $<$<BOOL:${PythonQt_SUPPORT_NAME_PROPERTY}>:PYTHONQT_SUPPORT_NAME_PROPERTY>
+)
+
+target_compile_options(PythonQt PRIVATE
+  $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+)
+
+target_include_directories(PythonQt
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<INSTALL_INTERFACE:${PythonQt_INSTALL_INCLUDE_DIR}>
+)
+
+target_link_libraries(PythonQt
+  PUBLIC
+    Python3::Python
+    ${QT_LIBRARIES}
+  PRIVATE
+    # Required for use of "QtCore/private/qmetaobjectbuilder_p.h" in "PythonQt.cpp"
+    Qt${PythonQt_QT_VERSION}::CorePrivate
+)
+
+#-----------------------------------------------------------------------------
+# Install library (on windows, put the dll in 'bin' and the archive in 'lib')
+
+install(TARGETS PythonQt
+  RUNTIME DESTINATION ${PythonQt_INSTALL_RUNTIME_DIR}
+  LIBRARY DESTINATION ${PythonQt_INSTALL_LIBRARY_DIR}
+  ARCHIVE DESTINATION ${PythonQt_INSTALL_ARCHIVE_DIR}
+)
+install(FILES ${pythonqt_headers} DESTINATION ${PythonQt_INSTALL_INCLUDE_DIR})

--- a/src/PythonQtConfigure.h.in
+++ b/src/PythonQtConfigure.h.in
@@ -1,9 +1,7 @@
-#ifndef _PYTHONQT_QTALL_H
-#define _PYTHONQT_QTALL_H
-
 /*
  *
- *  Copyright (C) 2010 MeVis Medical Solutions AG All Rights Reserved.
+ *  Copyright (C) 2025 MeVis Medical Solutions AG All Rights Reserved.
+ *  Copyright (C) 2025 Kitware, Inc.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -33,26 +31,15 @@
  *
  */
 
-// Export macro for the PythonQt_QtAll symbols.
-// Both qmake and CMake builds define PYTHONQT_QTALL_EXPORTS while building
-// the dedicated PythonQt_QtAll shared library.
-#if defined(WIN32)
-  #if defined(PYTHONQT_QTALL_EXPORTS)
-    #define PYTHONQT_QTALL_EXPORT __declspec(dllexport)
-  #else
-    #define PYTHONQT_QTALL_EXPORT __declspec(dllimport)
-  #endif
-#else
-  #if defined(PYTHONQT_QTALL_EXPORTS)
-    #define PYTHONQT_QTALL_EXPORT __attribute__((__visibility__("default")))
-  #else
-    #define PYTHONQT_QTALL_EXPORT
-  #endif
-#endif
+#ifndef _PYTHONQTCONFIGURE_H
+#define _PYTHONQTCONFIGURE_H
 
-namespace PythonQt_QtAll {
-//! Initialize the Qt bindings enabled at configuration time
-PYTHONQT_QTALL_EXPORT void init();
-}
+// If the user has not pre-defined the macro, derive it from the CMake
+// configure-time variable `PYTHONQT_USE_RELEASE_PYTHON_FALLBACK`, which
+// mirrors the `PythonQt_USE_RELEASE_PYTHON_FALLBACK` (camelCase)  CMake
+// option.
+#ifndef PYTHONQT_USE_RELEASE_PYTHON_FALLBACK
+#cmakedefine PYTHONQT_USE_RELEASE_PYTHON_FALLBACK
+#endif
 
 #endif

--- a/src/PythonQtPythonInclude.h
+++ b/src/PythonQtPythonInclude.h
@@ -33,6 +33,8 @@
 #ifndef __PythonQtPythonInclude_h
 #define __PythonQtPythonInclude_h
 
+#include <PythonQtConfigure.h>
+
 // Undefine macros that features.h defines to avoid redefinition warning
 #ifdef _POSIX_C_SOURCE
   #undef _POSIX_C_SOURCE

--- a/src/generate_configure_h.py
+++ b/src/generate_configure_h.py
@@ -1,0 +1,50 @@
+"""
+Generate a C/C++ header from a CMake .in template for use with qmake builds.
+
+CMake processes .h.in files at configure time, replacing:
+    #cmakedefine VAR  ->  #define VAR      (when VAR is ON/defined)
+                                        ->  /* #undef VAR */ (when VAR is OFF/undefined)
+
+qmake builds should not force CMake option defaults, so this script converts
+#cmakedefine lines into commented undef lines.
+"""
+
+import re
+import sys
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(
+            f"Usage: {sys.argv[0]} <input.h.in> <output.h>",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    in_path, out_path = sys.argv[1], sys.argv[2]
+
+    with open(in_path) as f:
+        content = f.read()
+
+    # #cmakedefine VAR [rest] -> /* #undef VAR */
+    content = re.sub(
+        r"^#cmakedefine\s+([A-Za-z_][A-Za-z0-9_]*)\s*$",
+        r"/* #undef \1 */",
+        content,
+        flags=re.MULTILINE,
+    )
+
+    # #cmakedefine VAR REST -> /* #undef VAR */ /* REST */
+    content = re.sub(
+        r"^#cmakedefine\s+([A-Za-z_][A-Za-z0-9_]*)\s+(.+)$",
+        r"/* #undef \1 */ /* \2 */",
+        content,
+        flags=re.MULTILINE,
+    )
+
+    with open(out_path, "w") as f:
+        f.write(content)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/src.pro
+++ b/src/src.pro
@@ -29,6 +29,17 @@ QT += widgets core-private
 
 INCLUDEPATH += $$PWD
 
+# Generate PythonQtConfigure.h from template at qmake-configure time.
+# The script turns #cmakedefine directives (CMake syntax) into #undef comments,
+# enabling a pure qmake build without forcing CMake option defaults.
+!exists($$PWD/PythonQtConfigure.h) {
+    win32: PYTHONQT_PYTHON = python
+    else:  PYTHONQT_PYTHON = python3
+    system($$PYTHONQT_PYTHON $$PWD/generate_configure_h.py \
+        $$PWD/PythonQtConfigure.h.in \
+        $$PWD/PythonQtConfigure.h)
+}
+
 macx {
   contains(QT_MAJOR_VERSION, 6) {
     QMAKE_APPLE_DEVICE_ARCHS = x86_64 arm64

--- a/tests/PythonQtTestMain.cpp
+++ b/tests/PythonQtTestMain.cpp
@@ -41,7 +41,9 @@
 
 #include "PythonQt.h"
 #include "PythonQtTests.h"
-#include "PythonQtTestCleanup.h"
+#ifdef PythonQt_Wrap_QtCore
+  #include "PythonQtTestCleanup.h"
+#endif
 
 #include <QApplication>
 
@@ -54,10 +56,13 @@ int main(int argc, char* argv[])
     QTest::qExec(&test, argc, argv);
     return 0;
   }
-
   if (QProcessEnvironment::systemEnvironment().contains("PYTHONQT_RUN_ONLY_CLEANUP_TESTS")) {
+#ifdef PythonQt_Wrap_QtCore
     PythonQtTestCleanup cleanup;
     QTest::qExec(&cleanup, argc, argv);
+#else
+    std::cout << "Cleanup tests require PythonQt_Wrap_QtCore" << std::endl;
+#endif
     return 0;
   }
 


### PR DESCRIPTION
This PR is an effort previously discussed to bring in the CMake build system for modern cross compilation of C++ libraries. This PR includes the CMake build system as of https://github.com/commontk/PythonQt/tree/patched-v4.0.1-2026-03-16-5cd9b581f. The CommonTK organization is used by applications such as [3D Slicer](https://github.com/Slicer/Slicer) and [MITK](https://github.com/MITK/MITK). Using CMake to build PythonQt has been utilized successfully by 3D Slicer for well over a decade. Integration of this work back to the upstream has taken a long time due to multiple factors including MeVisLab's PythonQt source repository not on GitHub and 3D Slicer maintaining a series of patches that had not been contributed back to the upstream. Both situations have changed where PythonQt is on GitHub and the long list of patches were contributed to the upstream in the fall of 2025.

A large majority of this CMake work is due to the fantastic work by @jcfr who also worked to contribute the patches back to this upstream repo. Late last year JC made a job move to Nvidia and therefore contributions to 3D Slicer and the ecosystem of supporting open-source libraries has been limited. I submit this PR to keep this work going to bring the CommonTK fork of PythonQt back in sync with the MeVisLab PythonQt upstream. 

I provide all the commits here for the CMake development for historic reference, but maintainers could consider squashing of commits for less noise. 

I have created a new GitHub actions workflow as part of testing the CMake build system similar to the existing CI infrastructure. This PR doesn't currently remove the existing build system, though maintainers here could consider a replacement based on stabilization here and then avoid the complexity of maintaining 2 build systems.