### PR TITLE
Use Qt 6 for macOS workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,16 +205,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       macos-version:  ['latest']
-       python-version: ['3.9']
-       qt-version: ['5.9.*']
+       python-version: ['3.13']
+       qt-version: ['6.11.*']
        configuration: ['release','debug']
-       include:
-         - macos-version: 'latest'
-           python-version: '3.11'
-           qt-version: '5.12.*'
-           configuration: 'debug'
-    runs-on: macos-${{ matrix.macos-version }}
+    runs-on: macos-latest
     steps:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
@@ -223,8 +217,7 @@ jobs:
         host: 'mac'
         target: 'desktop'
         arch: 'clang_64'
-        modules: 'qtscript'
-        archives: 'qtmultimedia qtmacextras qtbase qttools'
+        modules: 'qt5compat qtscxml qtpositioning qtwebchannel qtmultimedia qtwebengine'
 
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6


### PR DESCRIPTION
- current macos does no longer support these

Note that these runners are deprecated and will be removed at some time, so the CI will not work anyway then.
Maybe instead we can just remove these...
Also, at the moment there seem to be no macos-14 runners available - this may be temporary, but they are probably already in the process of being phased out.

_Update_:

Found this on the [runners site](https://github.com/actions/runner-images):
> GitHub Actions announcing the deprecation process for macOS 14 and macOS 14 arm64. While the images are being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on July 6th, 2026 and the images will be fully unsupported by November 2nd, 2026 for GitHub Actions and Azure DevOps.

So it probably makes sense to remove the macos/Qt 5.x workflow right away. I'll update the PR to do that instead of using an older runner.
_Edit_: Done.